### PR TITLE
fix(deps): override js-yaml to ^4.2.0 (clear DoS advisory)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3330,10 +3330,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,8 @@
     "vue-tsc": "^3.3.5"
   },
   "overrides": {
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "js-yaml": "^4.2.0"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
## What

Adds a `js-yaml: ^4.2.0` entry to `frontend/package.json` `overrides`, bumping the transitively-resolved `js-yaml` from 4.1.1 → 4.2.0.

## Why

`js-yaml <= 4.1.1` has a quadratic-complexity DoS in merge-key handling via repeated aliases (patched in 4.2.0). It's the only Dependabot alert still present on `main` after the npm-group bump (#17) — the other 10 alerts were resolved by that PR (dompurify 3.4.11, markdown-it 14.2.0, form-data removed) and are awaiting Dependabot rescan.

It's pulled in only transitively, so direct bumps couldn't reach it:

- `openapi-typescript → @redocly/openapi-core → js-yaml`
- `stylelint → cosmiconfig → js-yaml`

## Verification

`4.2.0` is a patch-level release within 4.x. All green locally:
- `npm ci` → **0 vulnerabilities**
- `stylelint` (lint:css) — clean
- `openapi-typescript` codegen — runs, **identical output** (no generated-file changes)
- `vue-tsc` type-check — clean
- `vite build` — clean
- `vitest` — **406/406 pass**