### PR TITLE
feat(job-protocol): quick filter chips for execution traces

### DIFF
--- a/frontend/src/features/job-protocol/components/JobProtocolTraceTab.vue
+++ b/frontend/src/features/job-protocol/components/JobProtocolTraceTab.vue
@@ -369,18 +369,17 @@
                                         </span>
                                     </div>
 
-                                    <!-- File/category pills and search snippets are trace-search affordances: within a single
-                                         pass the file and category are constant and the snippet just echoes the event name, so
-                                         they only earn their space when a cross-pass search is active. -->
-                                    <template v-if="vm.hasActiveTraceFilters">
-                                        <div v-if="row.traceFilePath || row.traceEventCategory" class="event-meta-line">
-                                            <span v-if="row.traceFilePath" class="event-meta-pill event-meta-pill--path" :title="row.traceFilePath">{{ row.traceFilePath }}</span>
-                                            <span class="event-meta-pill">{{ row.traceEventCategory }}</span>
-                                        </div>
-                                        <div v-if="row.traceMatchSnippet" class="event-match-snippet"><strong>{{ row.traceMatchedField }}:</strong> {{ row.traceMatchSnippet }}</div>
-                                        <div v-if="row.traceContextSnippet" class="event-context-snippet">{{ row.traceContextSnippet }}</div>
-                                        <div v-else-if="row.traceHasLimitedMetadata" class="event-context-limitation">Supporting metadata or nearby trace context was not captured for this row.</div>
-                                    </template>
+                                    <!-- A searched row stays as compact as an unfiltered one. The file/category are constant
+                                         within a single pass (the file is already named by the selector), and the fuller context
+                                         lives in the detail modal, so search only adds a single clamped line showing what the
+                                         free-text query matched. A name match is skipped — the event name is already on the line
+                                         above, so echoing it here is just noise. -->
+                                    <div
+                                        v-if="vm.hasActiveTraceFilters && row.traceMatchSnippet && row.traceMatchedField !== 'eventName'"
+                                        class="event-match-snippet"
+                                    >
+                                        <strong>{{ row.traceMatchedField }}:</strong> {{ row.traceMatchSnippet }}
+                                    </div>
 
                                     <!-- A real error message gets its own attention-drawing block; evidence/finalization metadata
                                          already rides inline above as neutral pills. -->
@@ -526,8 +525,7 @@ function retryFileDiff() {
 
 .trace-filter-subtitle,
 .trace-filter-summary,
-.events-section-context,
-.event-context-limitation {
+.events-section-context {
     margin: 0;
     color: var(--color-text-muted);
     font-size: 0.85rem;
@@ -1149,13 +1147,6 @@ function retryFileDiff() {
     min-width: 0;
 }
 
-.event-meta-line {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    min-width: 0;
-}
-
 .event-meta-pill {
     display: inline-flex;
     align-items: center;
@@ -1182,24 +1173,16 @@ function retryFileDiff() {
     background: rgba(34, 211, 238, 0.09);
 }
 
-.event-match-snippet,
-.event-context-snippet,
-.event-context-limitation {
-    max-width: 100%;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-}
-
+/* A searched row keeps the compact single-line shape: the match snippet truncates with an ellipsis
+   rather than wrapping into the multi-line block the cards used before compacting. */
 .event-match-snippet {
+    max-width: 100%;
     color: var(--color-text);
-    font-size: 0.88rem;
-    line-height: 1.5;
-}
-
-.event-context-snippet {
-    color: var(--color-text-muted);
-    font-size: 0.84rem;
-    line-height: 1.5;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .timing-duration {

--- a/frontend/src/features/job-protocol/components/JobProtocolTraceTab.vue
+++ b/frontend/src/features/job-protocol/components/JobProtocolTraceTab.vue
@@ -37,6 +37,37 @@
                     </button>
                 </div>
             </div>
+            <div
+                v-show="!vm.isTraceSearchCollapsed"
+                class="trace-chip-row"
+                role="group"
+                aria-label="Quick filters"
+                data-testid="trace-chip-row"
+            >
+                <template v-for="(groupDef, groupIndex) in vm.traceChipGroups" :key="groupDef.group">
+                    <span v-if="groupIndex > 0" class="trace-chip-divider" aria-hidden="true"></span>
+                    <div class="trace-chip-group">
+                        <span class="trace-chip-group-label">{{ groupDef.label }}</span>
+                        <div class="trace-chip-group-chips">
+                            <button
+                                v-for="chip in vm.traceChips.filter(c => c.group === groupDef.group)"
+                                :key="chip.id"
+                                type="button"
+                                class="chip chip-sm trace-chip"
+                                :class="{ 'trace-chip--active': chip.isActive, 'trace-chip--disabled': chip.isDisabled }"
+                                :aria-pressed="chip.isActive"
+                                :disabled="chip.isDisabled"
+                                :title="chip.isDisabled ? 'No matching rows for the current filters' : undefined"
+                                :data-testid="`trace-chip-${chip.id}`"
+                                @click="vm.toggleTraceChip(chip.id)"
+                            >
+                                <span class="trace-chip-label">{{ chip.label }}</span>
+                                <span class="trace-chip-count" data-testid="trace-chip-count">{{ chip.countLabel }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </template>
+            </div>
             <div v-show="!vm.isTraceSearchCollapsed" class="trace-filter-grid" data-testid="trace-search-panel">
                 <v-text-field
                     v-model="vm.traceFilters.queryText"
@@ -256,9 +287,20 @@
                             <p v-if="vm.hasActiveTraceFilters" class="events-section-context">Global trace search is active for this review.</p>
                         </div>
                         <p v-if="!vm.activePass.events?.length && !vm.hasActiveTraceFilters" class="empty-state">{{ vm.emptyPassMessage(vm.activePass) }}</p>
-                        <p v-else-if="vm.activePassEventRows.length === 0" class="empty-state trace-empty-state">
-                            {{ vm.visibleTraceRows.length === 0 ? 'No trace rows in this review match the current filters.' : 'No trace rows in this pass match the current filters.' }}
-                        </p>
+                        <div v-else-if="vm.activePassEventRows.length === 0" class="empty-state trace-empty-state" data-testid="trace-empty-state">
+                            <p class="trace-empty-state-message">
+                                {{ vm.visibleTraceRows.length === 0 ? 'No trace rows in this review match the current filters.' : 'No trace rows in this pass match the current filters.' }}
+                            </p>
+                            <button
+                                v-if="vm.hasActiveTraceFilters"
+                                type="button"
+                                class="btn-secondary btn-sm"
+                                data-testid="trace-empty-state-clear"
+                                @click="vm.clearTraceFilters"
+                            >
+                                Clear filters
+                            </button>
+                        </div>
                         <TransitionGroup v-else name="list" tag="div" class="events-list">
                             <article
                                 v-for="row in vm.activePassEventRows"
@@ -556,6 +598,105 @@ function retryFileDiff() {
     color: var(--color-text);
     background: rgba(34, 211, 238, 0.12);
     border-color: rgba(34, 211, 238, 0.28);
+}
+
+.trace-chip-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    row-gap: 0.5rem;
+}
+
+.trace-chip-divider {
+    width: 1px;
+    align-self: stretch;
+    min-height: 1.5rem;
+    background: var(--color-border);
+}
+
+.trace-chip-group {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    min-width: 0;
+}
+
+.trace-chip-group-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+
+.trace-chip-group-chips {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    min-width: 0;
+}
+
+/* Inactive chips read as outlined; active chips fill in the accent tint. The
+ * base .chip/.chip-sm primitives supply the pill shape and sizing. */
+.trace-chip {
+    appearance: none;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    font: inherit;
+    font-size: 0.7rem;
+    font-weight: 600;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.trace-chip:hover:not(.trace-chip--disabled) {
+    color: var(--color-text);
+    border-color: rgba(255, 255, 255, 0.18);
+}
+
+.trace-chip--active {
+    color: var(--color-accent);
+    background: var(--color-accent-soft, rgba(34, 211, 238, 0.15));
+    border-color: rgba(34, 211, 238, 0.4);
+}
+
+.trace-chip--disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.trace-chip-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    padding: 0 0.3rem;
+    border-radius: var(--radius-pill);
+    background: rgba(255, 255, 255, 0.1);
+    font-size: 0.66rem;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.trace-chip--active .trace-chip-count {
+    background: rgba(34, 211, 238, 0.22);
+    color: var(--color-accent);
+}
+
+.trace-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.trace-empty-state-message {
+    margin: 0;
 }
 
 .protocol-content {

--- a/frontend/src/features/job-protocol/components/__tests__/JobProtocolTraceTab.chips.spec.ts
+++ b/frontend/src/features/job-protocol/components/__tests__/JobProtocolTraceTab.chips.spec.ts
@@ -1,0 +1,257 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProtocolEventDto, ReviewProtocolPass } from '../../types'
+
+const routeQuery = ref<Record<string, string | undefined>>({})
+const replaceMock = vi.fn((location: { query?: Record<string, string | undefined> }) => {
+    if (location?.query) {
+        routeQuery.value = { ...location.query }
+    }
+    return Promise.resolve()
+})
+
+vi.mock('vue-router', async () => {
+    const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+    return {
+        ...actual,
+        useRoute: () => ({
+            params: { id: 'job-1' },
+            get query() {
+                return routeQuery.value
+            },
+        }),
+        useRouter: () => ({
+            push: vi.fn(),
+            replace: replaceMock,
+        }),
+        RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+    }
+})
+
+function event(overrides: Partial<ProtocolEventDto>): ProtocolEventDto {
+    return {
+        id: overrides.id ?? `${overrides.name}-${Math.random().toString(36).slice(2)}`,
+        kind: 'operational',
+        name: 'generic_event',
+        occurredAt: '2026-06-20T00:00:00Z',
+        ...overrides,
+    } as ProtocolEventDto
+}
+
+function buildProtocols(): ReviewProtocolPass[] {
+    return [
+        {
+            id: 'pass-baseline',
+            jobId: 'job-1',
+            attemptNumber: 1,
+            label: 'src/baseline.ts',
+            passKind: 'Baseline',
+            startedAt: '2026-06-20T00:00:00Z',
+            completedAt: '2026-06-20T00:01:00Z',
+            events: [
+                event({ id: 'b-gate-drop', name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Drop"}' }),
+                event({ id: 'b-gate-publish', name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Publish"}' }),
+                event({ id: 'b-discard', name: 'comment_relevance_filter_output', outputSummary: '{"discardedCount":2}' }),
+                event({ id: 'b-discard-evaluator', kind: 'aiCall', name: 'ai_call_comment_relevance_evaluator', outputSummary: '{"discardedCount":9}' }),
+                event({ id: 'b-memory', kind: 'memoryOperation', name: 'memory_reconsideration_completed' }),
+                event({ id: 'b-tool-ok', kind: 'toolCall', name: 'get_changed_files', toolOutcome: 'Completed' }),
+            ],
+        },
+        {
+            id: 'pass-highrisk',
+            jobId: 'job-1',
+            attemptNumber: 1,
+            label: 'src/risky.ts',
+            passKind: 'ProRVAugmentation',
+            reason: 'high-risk file re-review',
+            startedAt: '2026-06-20T00:02:00Z',
+            completedAt: '2026-06-20T00:03:00Z',
+            events: [
+                event({ id: 'h-error', kind: 'aiCall', name: 'ai_call_iter_1', error: 'model timeout' }),
+                event({ id: 'h-tool-failed', kind: 'toolCall', name: 'read_file', toolOutcome: 'Failed' }),
+            ],
+        },
+    ] as ReviewProtocolPass[]
+}
+
+let protocolsFixture: ReviewProtocolPass[] = []
+
+vi.mock('@/services/api', () => ({
+    createAdminClient: () => ({
+        GET: vi.fn((path: string) => {
+            if (path === '/jobs/{id}/protocol') {
+                return Promise.resolve({ data: protocolsFixture, error: null })
+            }
+            if (path === '/jobs/{id}/result') {
+                return Promise.resolve({ data: { status: 'completed' }, error: null })
+            }
+            if (path === '/jobs/{id}') {
+                return Promise.resolve({ data: { status: 'completed', tokenBreakdown: [] }, error: null })
+            }
+            if (path === '/jobs/{id}/protocol/{protocolId}') {
+                return Promise.resolve({ data: null, error: null })
+            }
+            return Promise.resolve({ data: null, error: null })
+        }),
+    }),
+}))
+
+vi.mock('@/services/findingDismissalsService', () => ({ createDismissal: vi.fn() }))
+vi.mock('@/services/jobsService', () => ({ restartJob: vi.fn() }))
+
+import { useJobProtocolViewModel } from '../../composables/useJobProtocolViewModel'
+import JobProtocolTraceTab from '../JobProtocolTraceTab.vue'
+
+const Host = defineComponent({
+    setup(_, { expose }) {
+        const vm = useJobProtocolViewModel()
+        vm.activeTab = 'traces'
+        expose({ vm })
+        return () => h(JobProtocolTraceTab, { vm })
+    },
+})
+
+async function mountTab() {
+    const wrapper = mount(Host, {
+        global: {
+            stubs: {
+                RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+                Teleport: true,
+            },
+        },
+    })
+
+    // Let onMounted load, the traces-tab watcher run, and reactive recompute settle.
+    await flushPromises()
+    await flushPromises()
+    // Reveal the chip row (the toolbar starts collapsed).
+    const vm = (wrapper.vm as unknown as { vm: ReturnType<typeof useJobProtocolViewModel> }).vm
+    vm.isTraceSearchCollapsed = false
+    await flushPromises()
+    return { wrapper, vm }
+}
+
+function chip(wrapper: ReturnType<typeof mount>, id: string) {
+    return wrapper.find(`[data-testid="trace-chip-${id}"]`)
+}
+
+describe('JobProtocolTraceTab quick filter chips', () => {
+    beforeEach(() => {
+        protocolsFixture = buildProtocols()
+        routeQuery.value = {}
+        replaceMock.mockClear()
+    })
+
+    it('renders all six chips with live counts against the unfiltered data', async () => {
+        const { wrapper } = await mountTab()
+
+        expect(chip(wrapper, 'droppedByGate').find('[data-testid="trace-chip-count"]').text()).toBe('1')
+        expect(chip(wrapper, 'highRiskReReview').find('[data-testid="trace-chip-count"]').text()).toBe('2')
+        expect(chip(wrapper, 'commentRelevanceDiscarded').find('[data-testid="trace-chip-count"]').text()).toBe('1')
+        expect(chip(wrapper, 'memoryReconsiderations').find('[data-testid="trace-chip-count"]').text()).toBe('1')
+        expect(chip(wrapper, 'errorsPresent').find('[data-testid="trace-chip-count"]').text()).toBe('1')
+        expect(chip(wrapper, 'toolCallFailed').find('[data-testid="trace-chip-count"]').text()).toBe('1')
+    })
+
+    it('activating a chip narrows the visible rows and prunes empty sidebar passes', async () => {
+        const { wrapper, vm } = await mountTab()
+
+        await chip(wrapper, 'droppedByGate').trigger('click')
+        await flushPromises()
+
+        expect(vm.activeTraceChipIds.has('droppedByGate')).toBe(true)
+        // Only the single drop row remains visible across the whole review.
+        expect(vm.visibleTraceRows.length).toBe(1)
+        expect(vm.visibleTraceRows[0].id).toBe('b-gate-drop')
+        // The high-risk pass has no drop rows, so it is pruned from the tree.
+        expect(vm.visiblePassCount).toBe(1)
+    })
+
+    it('ORs chips within a group and ANDs across groups', async () => {
+        const { wrapper, vm } = await mountTab()
+
+        // Two failure-cost chips OR together: error row + failed-tool row = 2 rows.
+        await chip(wrapper, 'errorsPresent').trigger('click')
+        await chip(wrapper, 'toolCallFailed').trigger('click')
+        await flushPromises()
+        expect(vm.visibleTraceRows.length).toBe(2)
+
+        // Adding a gate-outcome chip ANDs across groups; no row is both a drop and an error/failed-tool.
+        await chip(wrapper, 'droppedByGate').trigger('click')
+        await flushPromises()
+        expect(vm.visibleTraceRows.length).toBe(0)
+    })
+
+    it('encodes active chips into the URL and clears them via Clear filters', async () => {
+        const { wrapper, vm } = await mountTab()
+
+        await chip(wrapper, 'errorsPresent').trigger('click')
+        await flushPromises()
+
+        expect(replaceMock).toHaveBeenCalled()
+        expect(routeQuery.value.traceChips).toBe('errorsPresent')
+
+        vm.clearTraceFilters()
+        await flushPromises()
+        expect(vm.activeTraceChipIds.size).toBe(0)
+        expect(routeQuery.value.traceChips).toBeUndefined()
+    })
+
+    it('restores chip state from the URL on mount', async () => {
+        routeQuery.value = { traceChips: 'memoryReconsiderations' }
+        const { vm } = await mountTab()
+
+        expect(vm.activeTraceChipIds.has('memoryReconsiderations')).toBe(true)
+        expect(vm.visibleTraceRows.length).toBe(1)
+        expect(vm.visibleTraceRows[0].id).toBe('b-memory')
+    })
+
+    it('shows the empty state with a clear action when no rows match', async () => {
+        const { wrapper, vm } = await mountTab()
+
+        await chip(wrapper, 'droppedByGate').trigger('click')
+        await chip(wrapper, 'errorsPresent').trigger('click')
+        await flushPromises()
+        expect(vm.visibleTraceRows.length).toBe(0)
+
+        const emptyState = wrapper.find('[data-testid="trace-empty-state"]')
+        expect(emptyState.exists()).toBe(true)
+        const clearButton = wrapper.find('[data-testid="trace-empty-state-clear"]')
+        expect(clearButton.exists()).toBe(true)
+
+        await clearButton.trigger('click')
+        await flushPromises()
+        expect(vm.activeTraceChipIds.size).toBe(0)
+    })
+
+    it('disables a chip with zero matches and ignores clicks on it', async () => {
+        // A data set with no gate-drop, comment-relevance, or memory rows leaves
+        // those chips at zero and therefore disabled.
+        protocolsFixture = [
+            {
+                id: 'pass-only-tools',
+                jobId: 'job-1',
+                attemptNumber: 1,
+                label: 'src/only.ts',
+                passKind: 'Baseline',
+                startedAt: '2026-06-20T00:00:00Z',
+                completedAt: '2026-06-20T00:01:00Z',
+                events: [event({ id: 'ok-tool', kind: 'toolCall', name: 'read_file', toolOutcome: 'Completed' })],
+            },
+        ] as ReviewProtocolPass[]
+
+        const { wrapper, vm } = await mountTab()
+
+        const dropChip = chip(wrapper, 'droppedByGate')
+        expect(dropChip.attributes('disabled')).toBeDefined()
+        expect(dropChip.find('[data-testid="trace-chip-count"]').text()).toBe('0')
+
+        await dropChip.trigger('click')
+        await flushPromises()
+        expect(vm.activeTraceChipIds.has('droppedByGate')).toBe(false)
+    })
+})

--- a/frontend/src/features/job-protocol/composables/__tests__/traceQuickFilters.spec.ts
+++ b/frontend/src/features/job-protocol/composables/__tests__/traceQuickFilters.spec.ts
@@ -1,0 +1,245 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+import { describe, expect, it } from 'vitest'
+import type { ProtocolEventDto, ReviewProtocolPass } from '../../types'
+import {
+    deriveEventCategory,
+    formatTraceChipCount,
+    parseCommentRelevanceDiscardedCount,
+    parseTraceChipParam,
+    rowMatchesActiveChips,
+    serializeTraceChips,
+    traceChipDefinitions,
+} from '../traceQuickFilters'
+import type { TraceChipId } from '../traceQuickFilters'
+
+function pass(overrides: Partial<ReviewProtocolPass> = {}): ReviewProtocolPass {
+    return { id: 'pass-1', label: 'src/file.ts', ...overrides } as ReviewProtocolPass
+}
+
+function event(overrides: Partial<ProtocolEventDto> = {}): ProtocolEventDto {
+    return { kind: 'operational', name: 'some_event', ...overrides } as ProtocolEventDto
+}
+
+function chipMatches(id: TraceChipId, p: ReviewProtocolPass, e: ProtocolEventDto): boolean {
+    const definition = traceChipDefinitions.find(candidate => candidate.id === id)
+    if (!definition) throw new Error(`Unknown chip ${id}`)
+    return definition.matches(p, e)
+}
+
+describe('deriveEventCategory', () => {
+    it('prefers a persisted category', () => {
+        expect(deriveEventCategory('operational', 'anything', 'Comment-Relevance')).toBe('comment-relevance')
+    })
+
+    it('derives comment-relevance from the legacy name path when no category is persisted', () => {
+        expect(deriveEventCategory('operational', 'comment_relevance_filter_output', null)).toBe('comment-relevance')
+    })
+
+    it('derives memory from kind for legacy rows', () => {
+        expect(deriveEventCategory('memoryOperation', 'memory_reconsideration_completed', undefined)).toBe('memory')
+    })
+
+    it('falls back to operational for unknown rows', () => {
+        expect(deriveEventCategory('operational', 'mystery_event', null)).toBe('operational')
+    })
+})
+
+describe('parseCommentRelevanceDiscardedCount', () => {
+    it('reads a numeric discardedCount', () => {
+        expect(parseCommentRelevanceDiscardedCount('{"discardedCount":3}')).toBe(3)
+    })
+
+    it('reads a string discardedCount', () => {
+        expect(parseCommentRelevanceDiscardedCount('{"discardedCount":"5"}')).toBe(5)
+    })
+
+    it('treats truncated/unparseable JSON as no discards', () => {
+        expect(parseCommentRelevanceDiscardedCount('{"discardedCount":3, "keptCom')).toBe(0)
+    })
+
+    it('treats missing key as zero', () => {
+        expect(parseCommentRelevanceDiscardedCount('{"keptCount":2}')).toBe(0)
+    })
+
+    it('treats null/empty as zero', () => {
+        expect(parseCommentRelevanceDiscardedCount(null)).toBe(0)
+        expect(parseCommentRelevanceDiscardedCount('')).toBe(0)
+    })
+})
+
+describe('chip matching', () => {
+    describe('Dropped by gate', () => {
+        it('matches a review-finding-gate decision with disposition Drop', () => {
+            expect(chipMatches('droppedByGate', pass(), event({ name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Drop"}' }))).toBe(true)
+        })
+
+        it('matches a pr-wide final gate decision with disposition Drop', () => {
+            expect(chipMatches('droppedByGate', pass(), event({ name: 'pr_wide_final_gate_decision', outputSummary: '{"disposition":"Drop"}' }))).toBe(true)
+        })
+
+        it('does not match a Publish disposition', () => {
+            expect(chipMatches('droppedByGate', pass(), event({ name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Publish"}' }))).toBe(false)
+        })
+
+        it('does not match a non-gate event with disposition Drop', () => {
+            expect(chipMatches('droppedByGate', pass(), event({ name: 'some_other_event', outputSummary: '{"disposition":"Drop"}' }))).toBe(false)
+        })
+
+        it('does not match when the output summary is unparseable', () => {
+            expect(chipMatches('droppedByGate', pass(), event({ name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Dro' }))).toBe(false)
+        })
+    })
+
+    describe('High-risk re-review', () => {
+        it('matches a ProRVAugmentation pass kind', () => {
+            expect(chipMatches('highRiskReReview', pass({ passKind: 'ProRVAugmentation' }), event())).toBe(true)
+        })
+
+        it('matches a pass whose reason starts with "high-risk file"', () => {
+            expect(chipMatches('highRiskReReview', pass({ reason: 'high-risk file re-review triggered' }), event())).toBe(true)
+        })
+
+        it('does not match a baseline pass with an unrelated reason', () => {
+            expect(chipMatches('highRiskReReview', pass({ passKind: 'Baseline', reason: 'routine pass' }), event())).toBe(false)
+        })
+
+        it('does not match a PR-wide pass with no relevant metadata', () => {
+            expect(chipMatches('highRiskReReview', pass({ passKind: null, reason: null }), event())).toBe(false)
+        })
+    })
+
+    describe('Comment-relevance discarded', () => {
+        const discardNames = [
+            'comment_relevance_filter_output',
+            'comment_relevance_filter_degraded',
+            'comment_relevance_evaluator_degraded',
+            'comment_relevance_filter_selection_fallback',
+        ]
+
+        it.each(discardNames)('matches %s when discardedCount > 0', name => {
+            expect(chipMatches('commentRelevanceDiscarded', pass(), event({ name, outputSummary: '{"discardedCount":2}' }))).toBe(true)
+        })
+
+        it('does not match when discardedCount is 0', () => {
+            expect(chipMatches('commentRelevanceDiscarded', pass(), event({ name: 'comment_relevance_filter_output', outputSummary: '{"discardedCount":0}' }))).toBe(false)
+        })
+
+        it('excludes the ai_call_comment_relevance_evaluator sibling even with discards', () => {
+            expect(chipMatches('commentRelevanceDiscarded', pass(), event({ kind: 'aiCall', name: 'ai_call_comment_relevance_evaluator', outputSummary: '{"discardedCount":4}' }))).toBe(false)
+        })
+
+        it('matches a legacy row by deriving the comment-relevance category from the name', () => {
+            // eventCategory deliberately omitted; the category must be derived from the name.
+            expect(chipMatches('commentRelevanceDiscarded', pass(), event({ name: 'comment_relevance_filter_output', eventCategory: null, outputSummary: '{"discardedCount":1}' }))).toBe(true)
+        })
+
+        it('treats a truncated output summary as no discards', () => {
+            expect(chipMatches('commentRelevanceDiscarded', pass(), event({ name: 'comment_relevance_filter_output', outputSummary: '{"discardedCount":3,"discar' }))).toBe(false)
+        })
+    })
+
+    describe('Memory reconsiderations', () => {
+        it('matches the memory_reconsideration_completed event', () => {
+            expect(chipMatches('memoryReconsiderations', pass(), event({ kind: 'memoryOperation', name: 'memory_reconsideration_completed' }))).toBe(true)
+        })
+
+        it('does not match other memory events', () => {
+            expect(chipMatches('memoryReconsiderations', pass(), event({ kind: 'memoryOperation', name: 'memory_operation_failed' }))).toBe(false)
+        })
+    })
+
+    describe('Errors present', () => {
+        it('matches a row with a non-empty error', () => {
+            expect(chipMatches('errorsPresent', pass(), event({ error: 'boom' }))).toBe(true)
+        })
+
+        it('does not match a null error', () => {
+            expect(chipMatches('errorsPresent', pass(), event({ error: null }))).toBe(false)
+        })
+
+        it('does not match a whitespace-only error', () => {
+            expect(chipMatches('errorsPresent', pass(), event({ error: '   ' }))).toBe(false)
+        })
+    })
+
+    describe('Tool call failed', () => {
+        it('matches a failed tool call', () => {
+            expect(chipMatches('toolCallFailed', pass(), event({ kind: 'toolCall', toolOutcome: 'Failed' }))).toBe(true)
+        })
+
+        it('does not match a succeeded tool call', () => {
+            expect(chipMatches('toolCallFailed', pass(), event({ kind: 'toolCall', toolOutcome: 'Completed' }))).toBe(false)
+        })
+
+        it('does not match a failed non-tool event', () => {
+            expect(chipMatches('toolCallFailed', pass(), event({ kind: 'aiCall', toolOutcome: 'Failed' }))).toBe(false)
+        })
+    })
+})
+
+describe('rowMatchesActiveChips', () => {
+    const droppedEvent = event({ name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Drop"}' })
+    const errorEvent = event({ error: 'boom' })
+
+    it('matches everything when no chips are active', () => {
+        expect(rowMatchesActiveChips(pass(), event(), new Set())).toBe(true)
+    })
+
+    it('ORs chips within the same group', () => {
+        // errorsPresent and toolCallFailed are both in failure-cost.
+        const active = new Set<TraceChipId>(['errorsPresent', 'toolCallFailed'])
+        expect(rowMatchesActiveChips(pass(), errorEvent, active)).toBe(true)
+        expect(rowMatchesActiveChips(pass(), event({ kind: 'toolCall', toolOutcome: 'Failed' }), active)).toBe(true)
+        expect(rowMatchesActiveChips(pass(), event(), active)).toBe(false)
+    })
+
+    it('ANDs chips across different groups', () => {
+        // droppedByGate (gate-outcome) AND errorsPresent (failure-cost).
+        const active = new Set<TraceChipId>(['droppedByGate', 'errorsPresent'])
+        // A drop event without an error fails the failure-cost group.
+        expect(rowMatchesActiveChips(pass(), droppedEvent, active)).toBe(false)
+        // A drop event that also carries an error passes both groups.
+        const dropAndError = event({ name: 'review_finding_gate_decision', outputSummary: '{"disposition":"Drop"}', error: 'boom' })
+        expect(rowMatchesActiveChips(pass(), dropAndError, active)).toBe(true)
+    })
+})
+
+describe('URL serialization', () => {
+    it('serializes active chips in definition order', () => {
+        expect(serializeTraceChips(new Set<TraceChipId>(['errorsPresent', 'droppedByGate']))).toBe('droppedByGate,errorsPresent')
+    })
+
+    it('serializes an empty set to null', () => {
+        expect(serializeTraceChips(new Set())).toBeNull()
+    })
+
+    it('parses a comma-separated token list, ignoring unknown and duplicate tokens', () => {
+        expect(parseTraceChipParam('droppedByGate,bogus,droppedByGate,errorsPresent')).toEqual(['droppedByGate', 'errorsPresent'])
+    })
+
+    it('parses array-form query values', () => {
+        expect(parseTraceChipParam(['droppedByGate', 'errorsPresent'])).toEqual(['droppedByGate', 'errorsPresent'])
+    })
+
+    it('round-trips through serialize and parse', () => {
+        const active = new Set<TraceChipId>(['memoryReconsiderations', 'toolCallFailed'])
+        const serialized = serializeTraceChips(active)
+        expect(serialized).not.toBeNull()
+        expect(new Set(parseTraceChipParam(serialized))).toEqual(active)
+    })
+})
+
+describe('formatTraceChipCount', () => {
+    it('formats counts below the cap directly', () => {
+        expect(formatTraceChipCount(0)).toBe('0')
+        expect(formatTraceChipCount(42)).toBe('42')
+        expect(formatTraceChipCount(999)).toBe('999')
+    })
+
+    it('caps at 1000+', () => {
+        expect(formatTraceChipCount(1000)).toBe('1000+')
+        expect(formatTraceChipCount(5000)).toBe('1000+')
+    })
+})

--- a/frontend/src/features/job-protocol/composables/traceQuickFilters.ts
+++ b/frontend/src/features/job-protocol/composables/traceQuickFilters.ts
@@ -1,0 +1,279 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+import type { ProtocolEventDto, ReviewProtocolPass } from '../types'
+
+/**
+ * Pure matching logic for the one-click quick-filter chips on the execution
+ * trace toolbar. Each chip narrows the visible trace rows for a single job.
+ * Chips in the same group OR together; chips from different groups AND; the
+ * whole chip set ANDs with the free-text/file-path/model filters and the
+ * "Final findings only" toggle. Keeping these predicates pure keeps them
+ * unit-testable and reusable from the trace-search composable.
+ */
+
+/** Stable identifier for a quick-filter chip, also used as its URL token. */
+export type TraceChipId =
+    | 'droppedByGate'
+    | 'highRiskReReview'
+    | 'commentRelevanceDiscarded'
+    | 'memoryReconsiderations'
+    | 'errorsPresent'
+    | 'toolCallFailed'
+
+/** Visual grouping for chips. Same-group chips OR; cross-group chips AND. */
+export type TraceChipGroup = 'gate-outcome' | 'risk-rereview' | 'pre-gate-override' | 'failure-cost'
+
+export interface TraceChipDefinition {
+    id: TraceChipId
+    label: string
+    group: TraceChipGroup
+    /** Whether a row in the given pass matches this chip's intent. */
+    matches: (pass: ReviewProtocolPass, event: ProtocolEventDto) => boolean
+}
+
+/** Display order and copy for each group divider. */
+export const traceChipGroups: ReadonlyArray<{ group: TraceChipGroup; label: string }> = [
+    { group: 'gate-outcome', label: 'Gate outcome' },
+    { group: 'risk-rereview', label: 'Risk & re-review' },
+    { group: 'pre-gate-override', label: 'Pre-gate & override' },
+    { group: 'failure-cost', label: 'Failure & cost' },
+]
+
+const finalGateDecisionNames = new Set([
+    'review_finding_gate_decision',
+    'pr_wide_final_gate_decision',
+])
+
+const commentRelevanceDiscardNames = new Set([
+    'comment_relevance_filter_output',
+    'comment_relevance_filter_degraded',
+    'comment_relevance_evaluator_degraded',
+    'comment_relevance_filter_selection_fallback',
+])
+
+function normalize(value: string | null | undefined): string {
+    return (value ?? '').trim().toLowerCase()
+}
+
+/**
+ * Re-derives the event category the same way the trace-search composable does,
+ * so chips match both new rows (with a persisted `eventCategory`) and legacy
+ * rows (where it must be inferred from kind/name).
+ */
+export function deriveEventCategory(
+    kind: string | null | undefined,
+    name: string | null | undefined,
+    eventCategory?: string | null,
+): string {
+    const normalizedCategory = normalize(eventCategory)
+    if (normalizedCategory) return normalizedCategory
+
+    const normalizedKind = normalize(kind)
+    const normalizedName = normalize(name)
+
+    if (normalizedKind === 'memoryoperation') return 'memory'
+    if (normalizedName.startsWith('dedup_')) return 'duplicate-suppression'
+    if (normalizedName.includes('comment_relevance')) return 'comment-relevance'
+    if (normalizedName.includes('verification')) return 'verification'
+    if (normalizedName.includes('review_finding_gate') || normalizedName.includes('summary_reconciliation') || normalizedName.includes('repeated_judgment')) return 'review-finding-gate'
+    if (normalizedName.includes('prorv')) return 'prorv-prefilter'
+    if (normalizedName.includes('pr_wide')) return 'pr-wide-review'
+    if (normalizedName.includes('review_strategy') || normalizedName.includes('agentic_file') || normalizedName.includes('review_agent_session') || normalizedName.includes('prompt_stage_evidence') || normalizedName.includes('review_step_skipped')) return 'review-strategy'
+    if (normalizedKind === 'aicall') return 'ai-call'
+    if (normalizedKind === 'toolcall') return 'tool-call'
+    return 'operational'
+}
+
+/**
+ * Reads the `discardedCount` from a comment-relevance output summary. The
+ * `OutputSummary` is capped at ~1000 chars upstream, so a truncated or
+ * otherwise unparseable payload is treated as "no discards" rather than failing
+ * the chip.
+ */
+export function parseCommentRelevanceDiscardedCount(outputSummary: string | null | undefined): number {
+    if (!outputSummary) return 0
+
+    try {
+        const parsed = JSON.parse(outputSummary) as unknown
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return 0
+        }
+
+        const value = (parsed as Record<string, unknown>).discardedCount
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value
+        }
+
+        if (typeof value === 'string') {
+            const numeric = Number.parseInt(value, 10)
+            return Number.isFinite(numeric) ? numeric : 0
+        }
+
+        return 0
+    } catch {
+        return 0
+    }
+}
+
+function isFinalGateDropEvent(event: ProtocolEventDto): boolean {
+    if (!finalGateDecisionNames.has(normalize(event.name))) {
+        return false
+    }
+
+    const disposition = parseFinalGateDisposition(event.outputSummary)
+    return disposition === 'drop'
+}
+
+function parseFinalGateDisposition(outputSummary: string | null | undefined): string | null {
+    if (!outputSummary) return null
+
+    try {
+        const parsed = JSON.parse(outputSummary) as unknown
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return null
+        }
+
+        const value = (parsed as Record<string, unknown>).disposition
+        return typeof value === 'string' ? normalize(value) : null
+    } catch {
+        return null
+    }
+}
+
+function isHighRiskReReviewPass(pass: ReviewProtocolPass): boolean {
+    if (normalize(pass.passKind) === 'prorvaugmentation') {
+        return true
+    }
+
+    return normalize(pass.reason).startsWith('high-risk file')
+}
+
+function isCommentRelevanceDiscardEvent(event: ProtocolEventDto): boolean {
+    const category = deriveEventCategory(event.kind, event.name, event.eventCategory)
+    if (category !== 'comment-relevance') {
+        return false
+    }
+
+    // The sibling AI-call evaluator event shares the category but is not a
+    // discard signal, so it is excluded by restricting to the operational
+    // filter/evaluator events below.
+    if (!commentRelevanceDiscardNames.has(normalize(event.name))) {
+        return false
+    }
+
+    return parseCommentRelevanceDiscardedCount(event.outputSummary) > 0
+}
+
+export const traceChipDefinitions: ReadonlyArray<TraceChipDefinition> = [
+    {
+        id: 'droppedByGate',
+        label: 'Dropped by gate',
+        group: 'gate-outcome',
+        matches: (_pass, event) => isFinalGateDropEvent(event),
+    },
+    {
+        id: 'highRiskReReview',
+        label: 'High-risk re-review',
+        group: 'risk-rereview',
+        matches: pass => isHighRiskReReviewPass(pass),
+    },
+    {
+        id: 'commentRelevanceDiscarded',
+        label: 'Comment-relevance discarded',
+        group: 'pre-gate-override',
+        matches: (_pass, event) => isCommentRelevanceDiscardEvent(event),
+    },
+    {
+        id: 'memoryReconsiderations',
+        label: 'Memory reconsiderations',
+        group: 'pre-gate-override',
+        matches: (_pass, event) => normalize(event.name) === 'memory_reconsideration_completed',
+    },
+    {
+        id: 'errorsPresent',
+        label: 'Errors present',
+        group: 'failure-cost',
+        matches: (_pass, event) => (event.error ?? '').trim().length > 0,
+    },
+    {
+        id: 'toolCallFailed',
+        label: 'Tool call failed',
+        group: 'failure-cost',
+        matches: (_pass, event) => normalize(event.kind) === 'toolcall' && normalize(event.toolOutcome) === 'failed',
+    },
+]
+
+const chipById = new Map<TraceChipId, TraceChipDefinition>(
+    traceChipDefinitions.map(definition => [definition.id, definition]),
+)
+
+const validChipIds = new Set<TraceChipId>(traceChipDefinitions.map(definition => definition.id))
+
+/** True when a string is a known chip id. */
+export function isTraceChipId(value: string): value is TraceChipId {
+    return validChipIds.has(value as TraceChipId)
+}
+
+/**
+ * Evaluates a row against the active chip set. Same-group chips OR; chips from
+ * different groups AND. An empty active set matches everything.
+ */
+export function rowMatchesActiveChips(
+    pass: ReviewProtocolPass,
+    event: ProtocolEventDto,
+    activeChipIds: ReadonlySet<TraceChipId>,
+): boolean {
+    if (activeChipIds.size === 0) {
+        return true
+    }
+
+    const groupsWithActiveChips = new Map<TraceChipGroup, TraceChipDefinition[]>()
+    for (const id of activeChipIds) {
+        const definition = chipById.get(id)
+        if (!definition) continue
+        const existing = groupsWithActiveChips.get(definition.group) ?? []
+        existing.push(definition)
+        groupsWithActiveChips.set(definition.group, existing)
+    }
+
+    for (const definitions of groupsWithActiveChips.values()) {
+        const groupMatches = definitions.some(definition => definition.matches(pass, event))
+        if (!groupMatches) {
+            return false
+        }
+    }
+
+    return true
+}
+
+/** Parses a comma-separated chip token list (e.g. from the URL) into known ids, order-stable and de-duplicated. */
+export function parseTraceChipParam(value: string | string[] | null | undefined): TraceChipId[] {
+    const raw = Array.isArray(value) ? value.join(',') : value ?? ''
+    const seen = new Set<TraceChipId>()
+    const result: TraceChipId[] = []
+    for (const token of raw.split(',')) {
+        const trimmed = token.trim()
+        if (isTraceChipId(trimmed) && !seen.has(trimmed)) {
+            seen.add(trimmed)
+            result.push(trimmed)
+        }
+    }
+    return result
+}
+
+/** Serializes the active chips to a stable, definition-ordered URL token list, or null when none are active. */
+export function serializeTraceChips(activeChipIds: ReadonlySet<TraceChipId>): string | null {
+    const ordered = traceChipDefinitions
+        .filter(definition => activeChipIds.has(definition.id))
+        .map(definition => definition.id)
+    return ordered.length > 0 ? ordered.join(',') : null
+}
+
+/** Display cap for chip count badges; counts at or above this render as "1000+". */
+export const TRACE_CHIP_COUNT_CAP = 1000
+
+/** Formats a raw chip match count for the badge, capping at "1000+". */
+export function formatTraceChipCount(count: number): string {
+    return count >= TRACE_CHIP_COUNT_CAP ? `${TRACE_CHIP_COUNT_CAP}+` : String(count)
+}

--- a/frontend/src/features/job-protocol/composables/useJobProtocolViewModel.ts
+++ b/frontend/src/features/job-protocol/composables/useJobProtocolViewModel.ts
@@ -12,6 +12,7 @@ import { originLabel, passKindLabel } from './passLabels'
 import { useFileDiff } from './useFileDiff'
 import { useTokenTotals } from './useTokenTotals'
 import { useTraceSearch } from './useTraceSearch'
+import { parseTraceChipParam, serializeTraceChips } from './traceQuickFilters'
 import type {
     AgenticInvestigationOutputRecord,
     CommentGroupComment,
@@ -143,6 +144,7 @@ export function useJobProtocolViewModel() {
     const {
         isTraceSearchCollapsed,
         traceFindingsOnly,
+        activeTraceChipIds,
         traceFilters,
         normalizedTraceFilters,
         hasActiveTraceFilters,
@@ -150,10 +152,15 @@ export function useJobProtocolViewModel() {
         traceSearchToggleIcon,
         traceSuggestions,
         traceAutocompleteValue,
+        traceChips,
+        traceChipGroups,
         setTraceFilterValue,
         buildTraceSearchableRow,
         matchesTraceFilters,
         protocolHasVisibleTraceRows,
+        toggleTraceChip,
+        setActiveTraceChips,
+        clearTraceChips,
         clearTraceFilters,
     } = useTraceSearch(protocols)
 
@@ -579,6 +586,14 @@ export function useJobProtocolViewModel() {
         }
     }
 
+    // Pass count after the active trace filters and chips are applied; the stat
+    // strip "Visible Passes" counter reflects this rather than the raw total.
+    const visiblePassCount = computed<number>(() =>
+        hasActiveTraceFilters.value || traceFindingsOnly.value
+            ? treeVisiblePasses.value.length
+            : protocols.value.length,
+    )
+
     const commentSidebarItems = computed<CommentSidebarItem[]>(() => {
         const comments = filteredCommentsForTree.value
         const root: CommentTreeNode = { name: '', path: '', children: {}, files: {} }
@@ -995,13 +1010,18 @@ export function useJobProtocolViewModel() {
         return presentation
     }
 
-    // Cache keyed by (protocol object, collapsed-set identity, filter snapshot) so unchanged passes skip full recompute
+    // Cache keyed by (protocol object, collapsed-set identity, filter snapshot) so unchanged passes skip full recompute.
+    // The filter snapshot covers both the text filters and the active quick-filter chips so chip toggles invalidate it.
     const eventRowsCache = new WeakMap<ReviewProtocolPass, { collapseKey: Set<string>, filterKey: string, rows: EventDisplayRow[] }>()
+
+    function traceFilterCacheKey(): string {
+        return `${JSON.stringify(normalizedTraceFilters.value)}|${serializeTraceChips(activeTraceChipIds.value) ?? ''}`
+    }
 
     function buildEventRows(protocol: ReviewProtocolPass | null | undefined): EventDisplayRow[] {
         if (protocol) {
             const expanded = expandedEventParents.value
-            const filterKey = JSON.stringify(normalizedTraceFilters.value)
+            const filterKey = traceFilterCacheKey()
             const cached = eventRowsCache.get(protocol)
             if (cached && cached.collapseKey === expanded && cached.filterKey === filterKey) {
                 return cached.rows
@@ -1135,7 +1155,7 @@ export function useJobProtocolViewModel() {
         if (protocol) {
             eventRowsCache.set(protocol, {
                 collapseKey: expandedEventParents.value,
-                filterKey: JSON.stringify(normalizedTraceFilters.value),
+                filterKey: traceFilterCacheKey(),
                 rows,
             })
         }
@@ -1673,7 +1693,16 @@ export function useJobProtocolViewModel() {
         }
     }
 
+    // Apply the chip set encoded in the URL to the active chips. Returns the
+    // canonical token list it applied so the writer can avoid redundant pushes.
+    function applyTraceChipsFromRoute(): string | null {
+        const chipIds = parseTraceChipParam(route.query.traceChips as string | string[] | undefined)
+        setActiveTraceChips(chipIds)
+        return serializeTraceChips(activeTraceChipIds.value)
+    }
+
     onMounted(() => {
+        applyTraceChipsFromRoute()
         void loadProtocol(true)
     })
 
@@ -1755,6 +1784,39 @@ export function useJobProtocolViewModel() {
             if (desiredPassId && desiredPassId !== activePassId.value) {
                 activePassId.value = desiredPassId
             }
+        },
+    )
+
+    // Mirror chip toggles into the URL query string so back/forward navigation
+    // and shared links restore the same chip state. Uses replace to avoid
+    // flooding history while toggling chips.
+    watch(activeTraceChipIds, () => {
+        const serialized = serializeTraceChips(activeTraceChipIds.value)
+        const current = typeof route.query.traceChips === 'string' ? route.query.traceChips : null
+        if (serialized === current) {
+            return
+        }
+
+        const nextQuery = { ...route.query }
+        if (serialized) {
+            nextQuery.traceChips = serialized
+        } else {
+            delete nextQuery.traceChips
+        }
+
+        void router.replace({ query: nextQuery })
+    })
+
+    // Restore chip state when the URL's chip param changes from outside (browser
+    // back/forward or a shared link landing on this view).
+    watch(
+        () => (typeof route.query.traceChips === 'string' ? route.query.traceChips : ''),
+        nextParam => {
+            if (serializeTraceChips(activeTraceChipIds.value) === (nextParam || null)) {
+                return
+            }
+
+            setActiveTraceChips(parseTraceChipParam(nextParam))
         },
     )
 
@@ -1937,6 +1999,9 @@ export function useJobProtocolViewModel() {
         focusedEventId,
         isTraceSearchCollapsed,
         traceFindingsOnly,
+        activeTraceChipIds,
+        traceChips,
+        traceChipGroups,
         traceFilters,
         detailTab,
         fileDiff,
@@ -1960,6 +2025,7 @@ export function useJobProtocolViewModel() {
         traceSearchToggleIcon,
         traceSuggestions,
         treeVisiblePasses,
+        visiblePassCount,
         sidebarItems,
         commentSidebarItems,
         groupedReviewComments,
@@ -2027,6 +2093,8 @@ export function useJobProtocolViewModel() {
         traceAutocompleteValue,
         setTraceFilterValue,
         protocolHasVisibleTraceRows,
+        toggleTraceChip,
+        clearTraceChips,
         clearTraceFilters,
         processEvents,
         buildEventRows,

--- a/frontend/src/features/job-protocol/composables/useTraceSearch.ts
+++ b/frontend/src/features/job-protocol/composables/useTraceSearch.ts
@@ -4,6 +4,28 @@
 import { computed, ref } from 'vue'
 import type { Ref } from 'vue'
 import type { ProtocolEventDto, ReviewProtocolPass, TraceSearchableRow } from '../types'
+import {
+    TRACE_CHIP_COUNT_CAP,
+    formatTraceChipCount,
+    rowMatchesActiveChips,
+    traceChipDefinitions,
+    traceChipGroups,
+} from './traceQuickFilters'
+import type { TraceChipGroup, TraceChipId } from './traceQuickFilters'
+
+/** View-model entry for one quick-filter chip rendered in the toolbar. */
+export interface TraceChipViewModel {
+    id: TraceChipId
+    label: string
+    group: TraceChipGroup
+    isActive: boolean
+    /** Number of rows this chip would match against the current non-chip filter state (uncapped). */
+    count: number
+    /** Display label for the count badge, capped at "1000+". */
+    countLabel: string
+    /** A chip with zero matches against the non-chip filter state is disabled. */
+    isDisabled: boolean
+}
 
 /**
  * Owns the trace-tab search/filter state and the row-matching logic. The
@@ -14,6 +36,7 @@ import type { ProtocolEventDto, ReviewProtocolPass, TraceSearchableRow } from '.
 export function useTraceSearch(protocols: Ref<ReviewProtocolPass[]>) {
     const isTraceSearchCollapsed = ref(true)
     const traceFindingsOnly = ref(false)
+    const activeTraceChipIds = ref<Set<TraceChipId>>(new Set())
     const traceFilters = ref({
         queryText: '',
         filePath: '',
@@ -28,8 +51,14 @@ export function useTraceSearch(protocols: Ref<ReviewProtocolPass[]>) {
         modelId: traceFilters.value.modelId.trim().toLowerCase(),
     }))
 
-    const hasActiveTraceFilters = computed(() =>
+    const hasActiveTextTraceFilters = computed(() =>
         Object.values(normalizedTraceFilters.value).some(value => value.length > 0),
+    )
+
+    const hasActiveTraceChips = computed(() => activeTraceChipIds.value.size > 0)
+
+    const hasActiveTraceFilters = computed(() =>
+        hasActiveTextTraceFilters.value || hasActiveTraceChips.value,
     )
 
     const traceSearchToggleLabel = computed(() => (isTraceSearchCollapsed.value ? 'Show filters' : 'Hide filters'))
@@ -180,13 +209,22 @@ export function useTraceSearch(protocols: Ref<ReviewProtocolPass[]>) {
         return row
     }
 
-    function matchesTraceFilters(protocol: ReviewProtocolPass, event: ProtocolEventDto): boolean {
+    // Row-level free-text/file-path/model matching, independent of the quick
+    // filter chips. The chip count badges are computed against this baseline so
+    // each badge reflects "how many rows this chip alone would add".
+    function matchesNonChipTraceFilters(protocol: ReviewProtocolPass, event: ProtocolEventDto): boolean {
         const filters = normalizedTraceFilters.value
         const row = buildTraceSearchableRow(protocol, event)
 
         if (filters.queryText && !row.matchSnippet) return false
         if (filters.filePath && !(row.filePath ?? '').toLowerCase().includes(filters.filePath)) return false
         if (filters.modelId && !(row.modelId ?? '').toLowerCase().includes(filters.modelId)) return false
+        return true
+    }
+
+    function matchesTraceFilters(protocol: ReviewProtocolPass, event: ProtocolEventDto): boolean {
+        if (!matchesNonChipTraceFilters(protocol, event)) return false
+        if (!rowMatchesActiveChips(protocol, event, activeTraceChipIds.value)) return false
         return true
     }
 
@@ -212,28 +250,120 @@ export function useTraceSearch(protocols: Ref<ReviewProtocolPass[]>) {
         )
     }
 
+    // Per-chip match counts against the non-chip filter baseline. Recomputed
+    // only when the loaded event data or the non-chip filters change; counting
+    // stops at the display cap so very large reviews stay cheap.
+    const traceChipCounts = computed<Record<TraceChipId, number>>(() => {
+        const counts = Object.fromEntries(
+            traceChipDefinitions.map(definition => [definition.id, 0]),
+        ) as Record<TraceChipId, number>
+
+        const remaining = new Set(traceChipDefinitions.map(definition => definition.id))
+
+        for (const protocol of protocols.value) {
+            for (const event of protocol.events ?? []) {
+                if (!matchesNonChipTraceFilters(protocol, event)) {
+                    continue
+                }
+
+                for (const definition of traceChipDefinitions) {
+                    if (!remaining.has(definition.id)) {
+                        continue
+                    }
+
+                    if (definition.matches(protocol, event)) {
+                        counts[definition.id] += 1
+                        if (counts[definition.id] >= TRACE_CHIP_COUNT_CAP) {
+                            remaining.delete(definition.id)
+                        }
+                    }
+                }
+
+                if (remaining.size === 0) {
+                    return counts
+                }
+            }
+        }
+
+        return counts
+    })
+
+    const traceChips = computed<TraceChipViewModel[]>(() =>
+        traceChipDefinitions.map(definition => {
+            const count = traceChipCounts.value[definition.id]
+            const isActive = activeTraceChipIds.value.has(definition.id)
+            return {
+                id: definition.id,
+                label: definition.label,
+                group: definition.group,
+                isActive,
+                count,
+                countLabel: formatTraceChipCount(count),
+                // A chip with no matches against the non-chip filters is disabled,
+                // unless it is already active (so it can still be toggled off).
+                isDisabled: count === 0 && !isActive,
+            }
+        }),
+    )
+
+    function toggleTraceChip(chipId: TraceChipId): void {
+        const next = new Set(activeTraceChipIds.value)
+        if (next.has(chipId)) {
+            next.delete(chipId)
+        } else {
+            const count = traceChipCounts.value[chipId] ?? 0
+            // Clicking a disabled chip is a no-op.
+            if (count === 0) {
+                return
+            }
+
+            next.add(chipId)
+        }
+
+        activeTraceChipIds.value = next
+    }
+
+    function setActiveTraceChips(chipIds: Iterable<TraceChipId>): void {
+        activeTraceChipIds.value = new Set(chipIds)
+    }
+
+    function clearTraceChips(): void {
+        if (activeTraceChipIds.value.size > 0) {
+            activeTraceChipIds.value = new Set()
+        }
+    }
+
     function clearTraceFilters() {
         traceFilters.value = {
             queryText: '',
             filePath: '',
             modelId: '',
         }
+        clearTraceChips()
     }
 
     return {
         isTraceSearchCollapsed,
         traceFindingsOnly,
+        activeTraceChipIds,
         traceFilters,
         normalizedTraceFilters,
+        hasActiveTextTraceFilters,
+        hasActiveTraceChips,
         hasActiveTraceFilters,
         traceSearchToggleLabel,
         traceSearchToggleIcon,
         traceSuggestions,
         traceAutocompleteValue,
+        traceChips,
+        traceChipGroups,
         setTraceFilterValue,
         buildTraceSearchableRow,
         matchesTraceFilters,
         protocolHasVisibleTraceRows,
+        toggleTraceChip,
+        setActiveTraceChips,
+        clearTraceChips,
         clearTraceFilters,
     }
 }

--- a/frontend/src/features/job-protocol/types.ts
+++ b/frontend/src/features/job-protocol/types.ts
@@ -333,6 +333,10 @@ export type ReviewProtocolPass = ReviewJobProtocolDto & {
     attemptNumber?: number
     label?: string | null
     outcome?: string | null
+    /** Review pass kind name (e.g. "Baseline", "ProRVAugmentation"); null for legacy/synthesis passes. */
+    passKind?: string | null
+    /** Human-readable reason this pass ran (e.g. a high-risk augmentation re-review); null for baseline/legacy. */
+    reason?: string | null
     resolvedReviewStrategy?: ReviewStrategy | null
     strategySelectionSource?: string | null
     fileOutcome?: ProtocolFileOutcome | null

--- a/frontend/src/features/job-protocol/views/JobProtocolView.vue
+++ b/frontend/src/features/job-protocol/views/JobProtocolView.vue
@@ -28,7 +28,7 @@
             <div class="job-stat-strip compact-stats">
                 <div class="stat-pill"><span class="stat-label">Job</span><span class="stat-value monospace-value" :title="vm.protocols[0].jobId">{{ vm.jobShortId }}</span></div>
                 <div class="stat-pill"><span class="stat-label">Duration</span><span class="stat-value">{{ vm.overallDuration }}</span></div>
-                <div class="stat-pill"><span class="stat-label">Visible Passes</span><span class="stat-value">{{ vm.protocols.length }}</span></div>
+                <div class="stat-pill"><span class="stat-label">Visible Passes</span><span class="stat-value" data-testid="visible-pass-count">{{ vm.visiblePassCount }}</span></div>
                 <div class="stat-pill"><span class="stat-label">Inherited</span><span class="stat-value">{{ vm.inheritedProtocolCount }}</span></div>
                 <div class="stat-pill"><span class="stat-label">Total Tokens</span><span class="stat-value fat-tokens">{{ vm.formatTokens(vm.totalInputTokens + vm.totalOutputTokens) }}</span></div>
                 <div class="stat-pill"><span class="stat-label">Cached Input</span><span class="stat-value fat-tokens">{{ vm.formatTokens(vm.totalCachedInputTokens) }}</span></div>

--- a/frontend/tests/views/JobProtocolView.spec.ts
+++ b/frontend/tests/views/JobProtocolView.spec.ts
@@ -2112,7 +2112,9 @@ describe('JobProtocolView — comment search and filter (T042)', () => {
     expect(wrapper.text()).not.toContain('posting duplicate suppression metadata')
     expect(wrapper.text()).toContain('Review src/foo.ts for suspicious auth behavior')
     expect(wrapper.text()).toContain('searching src/foo.ts for suspicious evidence')
-    expect(wrapper.text()).toContain('Found suspicious evidence in auth flow [REDACTED]')
+    // The fuller context snippet is no longer rendered inline — a searched card stays compact and the
+    // surrounding context lives in the detail modal.
+    expect(wrapper.text()).not.toContain('Found suspicious evidence in auth flow [REDACTED]')
     expect(wrapper.text()).toContain('Redacted')
   })
 
@@ -2145,7 +2147,7 @@ describe('JobProtocolView — comment search and filter (T042)', () => {
     expect(wrapper.text()).toContain('No trace rows in this review match the current filters.')
   })
 
-  it('shows explicit limitation messaging when a matching row has sparse metadata and no surrounding context', async () => {
+  it('keeps a sparse matched row compact — the limited-metadata flag without a verbose limitation line', async () => {
     mockGet.mockImplementation((path: string) => {
       if (path.includes('/protocol')) {
         return Promise.resolve({
@@ -2177,16 +2179,18 @@ describe('JobProtocolView — comment search and filter (T042)', () => {
     await tracesTab!.trigger('click')
     await flushPromises()
 
-    // The "Limited metadata" flag is always shown, but the verbose limitation message — like the
-    // file/category pills and match/context snippets — is a trace-search affordance: it explains why
-    // a *matched* row has no surrounding context, so it only renders while a search is active.
+    // Compact trace cards: the "Limited metadata" flag still rides inline, but the verbose limitation
+    // sentence the cards used before compacting is gone, so a searched row is no busier than an unfiltered one.
     await openTraceSearchPanel(wrapper)
     const queryInput = wrapper.get('[data-testid="trace-filter-query"] input')
     await queryInput.setValue('summary_reconciliation')
     await flushPromises()
 
     expect(wrapper.text()).toContain('Limited metadata')
-    expect(wrapper.text()).toContain('Supporting metadata or nearby trace context was not captured for this row.')
+    expect(wrapper.text()).not.toContain('Supporting metadata or nearby trace context was not captured for this row.')
+    // The query matches the event name, which already shows on the card line, so the snippet is suppressed
+    // rather than echoing the name a second time.
+    expect(wrapper.text()).not.toContain('eventName: summary_reconciliation')
   })
 
   it('can quickly filter the trace tree to files with final findings only', async () => {
@@ -2307,7 +2311,10 @@ describe('JobProtocolView — comment search and filter (T042)', () => {
     await flushPromises()
 
     expect((filePathInput.element as HTMLInputElement).value).toBe('src/bar.ts')
-    expect(wrapper.text()).toContain('bar trace output')
+    // Narrowed to the bar.ts pass only; its row renders compactly, so the outputSummary context snippet
+    // ("bar trace output") is no longer shown inline, and the foo.ts pass is filtered out.
+    expect(wrapper.text()).toContain('summary_reconciliation')
+    expect(wrapper.text()).not.toContain('bar trace output')
     expect(wrapper.text()).not.toContain('Found suspicious evidence in auth flow [REDACTED]')
 
     const clearButton = wrapper.find('button.trace-filter-clear')


### PR DESCRIPTION
## Summary

Adds a row of one-click quick-filter chips to the per-job execution-trace toolbar, scoped to a single job's already-loaded trace data. The chips give operators fast access to the most common triage questions without touching the backend.

This is a purely client-side change over data the existing trace endpoints already return — no new HTTP endpoints, no `openapi.json` changes, no new persistence (the URL query string is the only persistence).

## The six chips (by group)

**Gate outcome**
- **Dropped by gate** — `review_finding_gate_decision` / `pr_wide_final_gate_decision` rows whose parsed output `disposition` is `Drop`.

**Risk & re-review**
- **High-risk re-review** — rows in any pass where `passKind === "ProRVAugmentation"` or the pass `reason` starts with `"high-risk file"` (pipeline-agnostic; PR-wide passes simply don't match).

**Pre-gate & override**
- **Comment-relevance discarded** — rows in the four operational `comment_relevance_*` filter/evaluator events whose parsed output `discardedCount > 0`. The sibling `ai_call_comment_relevance_evaluator` is excluded.
- **Memory reconsiderations** — `memory_reconsideration_completed` rows.

**Failure & cost**
- **Errors present** — rows with a non-empty `error`.
- **Tool call failed** — `kind === "ToolCall"` rows with `toolOutcome === "Failed"`.

## Behaviour

- Same-group chips OR; cross-group chips AND; the whole chip set ANDs with the existing free-text/file-path/model filters.
- The existing **"Final findings only"** toggle is kept as an independent toggle that ANDs with the chips (per the product decision).
- Active chips are encoded in the URL (`?traceChips=...`); back/forward navigation, refresh, and shared links restore the same state.
- **"Clear filters"** clears chips and the text/file/model filters in one step.
- Each chip shows a live count of matching rows against the current non-chip filter state, memoized and capped at `1000+`. A chip with zero matches is disabled (clicking it is a no-op, with a tooltip explaining why).
- The stat-strip **"Visible Passes"** counter now reflects the post-filter pass count; the sidebar prunes passes with zero matching rows.
- An empty-state with a one-click clear action renders when no rows match.
- No change to the event detail modal, the Summary tab, or the Tokens tab.

## Implementation notes

- Chip matching lives in a new pure module, `traceQuickFilters.ts` (predicates, group/OR/AND evaluation, `discardedCount` / disposition parsing, URL encode/decode, count formatting), kept side-effect-free for unit testing.
- Chip reactive state, counts, and view models are added to the existing `useTraceSearch` composable; row matching ANDs the chip predicate into `matchesTraceFilters`. The event-rows cache key now includes the active chip signature so chip toggles invalidate it.
- Chip matching reuses the deterministic `(Kind, Name)` event-category derivation so it works for legacy rows that have no persisted `eventCategory`, and treats a truncated/unparseable comment-relevance output summary as "no discards".
- `passKind` / `reason` were added to the hand-written `ReviewProtocolPass` type extension (the backend already serializes them; the generated client was not regenerated, per the no-`openapi.json`-changes constraint).

## Tests

- Unit tests for all six chip predicates, the legacy `eventCategory` derivation path, the comment-relevance `discardedCount` parsing edge cases, group OR/AND evaluation, URL round-trip, and count capping.
- Component tests for clicking each chip, multi-chip selection across groups, URL encode + restore-on-mount, the "Clear filters" action, the empty state, and the disabled-chip no-op.
- `npm test` (460 passed), `npm run lint` (vue-tsc, clean), and stylelint on the changed component all green.

Closes #24
