### PR TITLE
feat(identity): re-enable disabled users + tighten admin-activation policy

### DIFF
--- a/frontend/src/features/users/views/UsersView.vue
+++ b/frontend/src/features/users/views/UsersView.vue
@@ -95,10 +95,19 @@
                 <button
                   v-if="user.isActive"
                   class="btn-danger"
-                  :disabled="disabling === user.id"
+                  :disabled="togglingActive === user.id"
                   @click="handleDisable(user.id)"
                 >
-                  {{ disabling === user.id ? '…' : 'Disable' }}
+                  {{ togglingActive === user.id ? '…' : 'Disable' }}
+                </button>
+                <button
+                  v-else
+                  class="btn-primary"
+                  :disabled="togglingActive === user.id"
+                  @click="handleReenable(user.id)"
+                >
+                  <i class="fi fi-rr-refresh"></i>
+                  {{ togglingActive === user.id ? '…' : 'Re-enable' }}
                 </button>
                 <button
                   class="btn-secondary"
@@ -174,6 +183,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useSession } from '@/composables/useSession'
+import { useNotification } from '@/composables/useNotification'
 import { API_BASE_URL } from '@/services/apiBase'
 
 interface UserItem {
@@ -198,6 +208,7 @@ interface ClientItem {
 }
 
 const { getAccessToken } = useSession()
+const { notify } = useNotification()
 const base = API_BASE_URL
 
 function authHeaders(): Record<string, string> {
@@ -209,7 +220,7 @@ function authHeaders(): Record<string, string> {
 const users = ref<UserItem[]>([])
 const loading = ref(false)
 const loadError = ref('')
-const disabling = ref<string | null>(null)
+const togglingActive = ref<string | null>(null)
 
 // Create user state
 const showCreate = ref(false)
@@ -289,15 +300,34 @@ async function handleCreate() {
 
 async function handleDisable(id: string) {
   if (!confirm('Disable this user? All their tokens and PATs will be revoked.')) return
-  disabling.value = id
+  await setUserActive(id, false)
+}
+
+async function handleReenable(id: string) {
+  if (!confirm('Re-enable this user? They will need to log in again.')) return
+  await setUserActive(id, true)
+}
+
+async function setUserActive(id: string, isActive: boolean) {
+  togglingActive.value = id
   try {
-    const res = await fetch(`${base}/admin/users/${id}`, { method: 'DELETE', headers: authHeaders() })
+    const res = await fetch(`${base}/admin/users/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ isActive }),
+    })
     if (res.ok) {
       const user = users.value.find(u => u.id === id)
-      if (user) user.isActive = false
+      if (user) user.isActive = isActive
+      notify(isActive ? 'User re-enabled.' : 'User disabled.', 'success')
+    } else {
+      const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` })) as { error?: string }
+      notify(body.error ?? `HTTP ${res.status}`, 'error')
     }
+  } catch (e) {
+    notify(String(e), 'error')
   } finally {
-    disabling.value = null
+    togglingActive.value = null
   }
 }
 

--- a/frontend/src/features/users/views/__tests__/UsersView.spec.ts
+++ b/frontend/src/features/users/views/__tests__/UsersView.spec.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+const notifyMock = vi.fn()
+
+vi.mock('@/composables/useSession', () => ({
+  useSession: () => ({ getAccessToken: () => 'test-token' }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({ notify: notifyMock }),
+}))
+
+const base = 'http://localhost/api'
+
+interface MockUser {
+  id: string
+  username: string
+  globalRole: string
+  isActive: boolean
+  createdAt: string
+}
+
+function mockRes(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) }
+}
+
+let users: MockUser[]
+let patchResponse: () => ReturnType<typeof mockRes>
+
+function installFetch() {
+  const fetchMock = global.fetch as unknown as Mock
+  fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+    const method = opts?.method ?? 'GET'
+    if (url === `${base}/admin/users` && method === 'GET') return Promise.resolve(mockRes(users))
+    if (url === `${base}/clients` && method === 'GET') return Promise.resolve(mockRes([]))
+    if (url.startsWith(`${base}/admin/users/`) && method === 'PATCH') return Promise.resolve(patchResponse())
+    return Promise.resolve(mockRes(null))
+  })
+}
+
+function findButton(wrapper: VueWrapper, label: string) {
+  return wrapper.findAll('button').find(b => b.text().trim() === label)
+}
+
+function patchCalls() {
+  const fetchMock = global.fetch as unknown as Mock
+  return fetchMock.mock.calls.filter(c => (c[1] as RequestInit | undefined)?.method === 'PATCH')
+}
+
+async function mountView() {
+  const { default: UsersView } = await import('@/features/users/views/UsersView.vue')
+  const wrapper = mount(UsersView)
+  await flushPromises()
+  return wrapper
+}
+
+describe('UsersView enable/disable actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    users = [
+      { id: 'active-admin', username: 'admin', globalRole: 'Admin', isActive: true, createdAt: '2026-01-01T00:00:00Z' },
+      { id: 'disabled-user', username: 'former.employee', globalRole: 'User', isActive: false, createdAt: '2026-01-01T00:00:00Z' },
+    ]
+    patchResponse = () => mockRes(null, 204)
+    window.confirm = vi.fn(() => true)
+    installFetch()
+  })
+
+  it('renders a Disable button on active rows and a Re-enable button on disabled rows', async () => {
+    const wrapper = await mountView()
+
+    expect(findButton(wrapper, 'Disable')).toBeTruthy()
+    expect(findButton(wrapper, 'Re-enable')).toBeTruthy()
+  })
+
+  it('disables an active user via PATCH with isActive=false and updates the row optimistically', async () => {
+    const wrapper = await mountView()
+
+    await findButton(wrapper, 'Disable')!.trigger('click')
+    await flushPromises()
+
+    const calls = patchCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0][0]).toBe(`${base}/admin/users/active-admin`)
+    expect(JSON.parse((calls[0][1] as RequestInit).body as string)).toEqual({ isActive: false })
+    expect(notifyMock).toHaveBeenCalledWith('User disabled.', 'success')
+    // Both rows are now disabled, so no Disable button remains.
+    expect(findButton(wrapper, 'Disable')).toBeUndefined()
+  })
+
+  it('re-enables a disabled user via PATCH with isActive=true', async () => {
+    const wrapper = await mountView()
+
+    await findButton(wrapper, 'Re-enable')!.trigger('click')
+    await flushPromises()
+
+    const calls = patchCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0][0]).toBe(`${base}/admin/users/disabled-user`)
+    expect(JSON.parse((calls[0][1] as RequestInit).body as string)).toEqual({ isActive: true })
+    expect(notifyMock).toHaveBeenCalledWith('User re-enabled.', 'success')
+  })
+
+  it('does not call the API when the confirm dialog is declined', async () => {
+    window.confirm = vi.fn(() => false)
+    const wrapper = await mountView()
+
+    await findButton(wrapper, 'Disable')!.trigger('click')
+    await flushPromises()
+
+    expect(patchCalls()).toHaveLength(0)
+    expect(notifyMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the server error message and leaves the row unchanged on a non-204 response', async () => {
+    patchResponse = () => mockRes({ error: 'Cannot disable the last active global admin.' }, 409)
+    const wrapper = await mountView()
+
+    await findButton(wrapper, 'Disable')!.trigger('click')
+    await flushPromises()
+
+    expect(notifyMock).toHaveBeenCalledWith('Cannot disable the last active global admin.', 'error')
+    // The optimistic update must not fire on failure: the active admin keeps its Disable button.
+    expect(findButton(wrapper, 'Disable')).toBeTruthy()
+  })
+})

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2514,7 +2514,8 @@ export const handlers = [
     await delay(400)
     return HttpResponse.json([
       { id: 'u1', username: 'admin', globalRole: 'Admin', isActive: true, createdAt: new Date().toISOString() },
-      { id: 'u2', username: 'jsmith', globalRole: 'User', isActive: true, createdAt: new Date().toISOString() }
+      { id: 'u2', username: 'jsmith', globalRole: 'User', isActive: true, createdAt: new Date().toISOString() },
+      { id: 'u3', username: 'former.employee', globalRole: 'User', isActive: false, createdAt: new Date().toISOString() }
     ])
   }),
 
@@ -2525,6 +2526,11 @@ export const handlers = [
          { assignmentId: 'a2', clientId: '2', role: 'ClientUser', assignedAt: new Date().toISOString() }
        ]
     })
+  }),
+
+  http.patch(`${base}/admin/users/:id`, async () => {
+    await delay(200)
+    return new HttpResponse(null, { status: 204 })
   }),
 
   http.get(`${base}/users/me/pats`, async () => {

--- a/frontend/src/services/generated/openapi.ts
+++ b/frontend/src/services/generated/openapi.ts
@@ -720,8 +720,15 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        /** Disables a user and revokes all their tokens and PATs. */
-        delete: {
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the
+         *     active flag actually flips, all refresh tokens and PATs are revoked so the user must
+         *     re-authenticate. Disabling the last active global admin is refused with 409.
+         */
+        patch: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -730,7 +737,13 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SetUserActiveRequest"];
+                    "text/json": components["schemas"]["SetUserActiveRequest"];
+                    "application/*+json": components["schemas"]["SetUserActiveRequest"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -741,9 +754,6 @@ export interface paths {
                 };
             };
         };
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/admin/users/{id}": {
@@ -776,8 +786,15 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        /** Disables a user and revokes all their tokens and PATs. */
-        delete: {
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the
+         *     active flag actually flips, all refresh tokens and PATs are revoked so the user must
+         *     re-authenticate. Disabling the last active global admin is refused with 409.
+         */
+        patch: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -786,7 +803,13 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SetUserActiveRequest"];
+                    "text/json": components["schemas"]["SetUserActiveRequest"];
+                    "application/*+json": components["schemas"]["SetUserActiveRequest"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -797,9 +820,6 @@ export interface paths {
                 };
             };
         };
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/admin/identity/users/{id}/clients": {
@@ -11974,6 +11994,10 @@ export interface components {
             login?: string | null;
             displayName?: string | null;
             isBot?: boolean;
+        };
+        /** @description Enable/disable request for a user. */
+        SetUserActiveRequest: {
+            isActive?: boolean;
         };
         /** @description Request payload for provider-neutral review intake. */
         SubmitReviewRequest: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -720,8 +720,15 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        /** Disables a user and revokes all their tokens and PATs. */
-        delete: {
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the
+         *     active flag actually flips, all refresh tokens and PATs are revoked so the user must
+         *     re-authenticate. Disabling the last active global admin is refused with 409.
+         */
+        patch: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -730,7 +737,13 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SetUserActiveRequest"];
+                    "text/json": components["schemas"]["SetUserActiveRequest"];
+                    "application/*+json": components["schemas"]["SetUserActiveRequest"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -741,9 +754,6 @@ export interface paths {
                 };
             };
         };
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/admin/users/{id}": {
@@ -776,8 +786,15 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        /** Disables a user and revokes all their tokens and PATs. */
-        delete: {
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the
+         *     active flag actually flips, all refresh tokens and PATs are revoked so the user must
+         *     re-authenticate. Disabling the last active global admin is refused with 409.
+         */
+        patch: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -786,7 +803,13 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SetUserActiveRequest"];
+                    "text/json": components["schemas"]["SetUserActiveRequest"];
+                    "application/*+json": components["schemas"]["SetUserActiveRequest"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -797,9 +820,6 @@ export interface paths {
                 };
             };
         };
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/admin/identity/users/{id}/clients": {
@@ -11974,6 +11994,10 @@ export interface components {
             login?: string | null;
             displayName?: string | null;
             isBot?: boolean;
+        };
+        /** @description Enable/disable request for a user. */
+        SetUserActiveRequest: {
+            isActive?: boolean;
         };
         /** @description Request payload for provider-neutral review intake. */
         SubmitReviewRequest: {

--- a/openapi.json
+++ b/openapi.json
@@ -893,11 +893,11 @@
       }
     },
     "/admin/identity/users/{id}": {
-      "delete": {
+      "patch": {
         "tags": [
           "AdminUsers"
         ],
-        "summary": "Disables a user and revokes all their tokens and PATs.",
+        "summary": "Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the\nactive flag actually flips, all refresh tokens and PATs are revoked so the user must\nre-authenticate. Disabling the last active global admin is refused with 409.",
         "parameters": [
           {
             "name": "id",
@@ -909,6 +909,25 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK"
@@ -939,11 +958,11 @@
       }
     },
     "/admin/users/{id}": {
-      "delete": {
+      "patch": {
         "tags": [
           "AdminUsers"
         ],
-        "summary": "Disables a user and revokes all their tokens and PATs.",
+        "summary": "Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the\nactive flag actually flips, all refresh tokens and PATs are revoked so the user must\nre-authenticate. Disabling the last active global admin is refused with 409.",
         "parameters": [
           {
             "name": "id",
@@ -955,6 +974,25 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserActiveRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK"
@@ -19768,6 +19806,16 @@
         },
         "additionalProperties": false,
         "description": "Request body for setting a client-scoped provider reviewer-trigger identity."
+      },
+      "SetUserActiveRequest": {
+        "type": "object",
+        "properties": {
+          "isActive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Enable/disable request for a user."
       },
       "SubmitReviewRequest": {
         "type": "object",

--- a/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/AdminUsersController.cs
+++ b/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/AdminUsersController.cs
@@ -15,7 +15,8 @@ public sealed class AdminUsersController(
     IUserRepository userRepository,
     IRefreshTokenRepository refreshTokenRepository,
     IUserPatRepository userPatRepository,
-    IPasswordHashService passwordHashService) : ControllerBase
+    IPasswordHashService passwordHashService,
+    IUserAccountAuditLog auditLog) : ControllerBase
 {
     /// <summary>Returns all users.</summary>
     [HttpGet("/admin/identity/users")]
@@ -73,15 +74,27 @@ public sealed class AdminUsersController(
         return this.CreatedAtAction(nameof(this.ListUsers), null, MapToResponse(user));
     }
 
-    /// <summary>Disables a user and revokes all their tokens and PATs.</summary>
-    [HttpDelete("/admin/identity/users/{id:guid}")]
-    [HttpDelete("/admin/users/{id:guid}")]
-    public async Task<IActionResult> DisableUser(Guid id, CancellationToken ct)
+    /// <summary>
+    ///     Enables or disables a user. Idempotent: confirming the current state is a no-op. Whenever the
+    ///     active flag actually flips, all refresh tokens and PATs are revoked so the user must
+    ///     re-authenticate. Disabling the last active global admin is refused with 409.
+    /// </summary>
+    [HttpPatch("/admin/identity/users/{id:guid}")]
+    [HttpPatch("/admin/users/{id:guid}")]
+    public async Task<IActionResult> SetUserActive(
+        Guid id,
+        [FromBody] SetUserActiveRequest? request,
+        CancellationToken ct)
     {
         var auth = AuthHelpers.RequireAdmin(this.HttpContext);
         if (auth is not null)
         {
             return auth;
+        }
+
+        if (request is null)
+        {
+            return this.BadRequest(new { error = "A request body with an isActive value is required." });
         }
 
         var user = await userRepository.GetByIdAsync(id, ct);
@@ -90,9 +103,38 @@ public sealed class AdminUsersController(
             return this.NotFound();
         }
 
-        await userRepository.SetActiveAsync(id, false, ct);
+        // Confirming the value the user already has changes nothing and leaves no audit trail.
+        if (user.IsActive == request.IsActive)
+        {
+            return this.NoContent();
+        }
+
+        var actorUserId = AuthHelpers.GetUserId(this.HttpContext) ?? Guid.Empty;
+
+        // Reaching here with request.IsActive == false means the user is currently active, so a global
+        // admin would lose their access; refuse when no other active global admin would remain.
+        if (!request.IsActive && user.GlobalRole == AppUserRole.Admin)
+        {
+            var activeAdmins = await userRepository.CountActiveAdminsAsync(ct);
+            if (activeAdmins <= 1)
+            {
+                auditLog.DisableBlockedByLastAdmin(actorUserId, user.Id, user.Username);
+                return this.Conflict(new { error = "Cannot disable the last active global admin." });
+            }
+        }
+
+        await userRepository.SetActiveAsync(id, request.IsActive, ct);
         await refreshTokenRepository.RevokeAllForUserAsync(id, ct);
         await userPatRepository.RevokeAllForUserAsync(id, ct);
+
+        if (request.IsActive)
+        {
+            auditLog.Reenabled(actorUserId, user.Id, user.Username);
+        }
+        else
+        {
+            auditLog.Disabled(actorUserId, user.Id, user.Username);
+        }
 
         return this.NoContent();
     }
@@ -191,6 +233,9 @@ public sealed class AdminUsersController(
 
 /// <summary>Create-user request.</summary>
 public sealed record CreateUserRequest(string Username, string Password, AppUserRole? GlobalRole);
+
+/// <summary>Enable/disable request for a user.</summary>
+public sealed record SetUserActiveRequest(bool IsActive);
 
 /// <summary>Assign-client-role request.</summary>
 public sealed record AssignClientRoleRequest(Guid ClientId, ClientRole Role);

--- a/src/MeisterProPR.Api/Features/IdentityAndAccess/Middleware/AuthMiddleware.cs
+++ b/src/MeisterProPR.Api/Features/IdentityAndAccess/Middleware/AuthMiddleware.cs
@@ -60,6 +60,16 @@ public sealed class AuthMiddleware(RequestDelegate next)
                             if (userRepo is not null)
                             {
                                 var user = await userRepo.GetByIdWithAssignmentsAsync(userId, context.RequestAborted);
+
+                                // A still-valid access token must not outlive a disabled account: the
+                                // refresh-token and PAT paths already reject disabled users, and this
+                                // closes the same gap for bearer JWTs.
+                                if (user is not null && !user.IsActive)
+                                {
+                                    await WriteNotActiveAsync(context);
+                                    return;
+                                }
+
                                 var explicitClientRoles = user is not null
                                     ? CreateExplicitClientRoles(user)
                                     : await userRepo.GetUserClientRolesAsync(userId, context.RequestAborted);
@@ -113,11 +123,25 @@ public sealed class AuthMiddleware(RequestDelegate next)
                         await next(context);
                         return;
                     }
+
+                    // Defense in depth: PATs are revoked when a user is disabled, so this should not
+                    // normally fire, but reject explicitly if a live PAT ever outlives the account.
+                    if (user is not null && !user.IsActive)
+                    {
+                        await WriteNotActiveAsync(context);
+                        return;
+                    }
                 }
             }
         }
 
         await next(context);
+    }
+
+    private static Task WriteNotActiveAsync(HttpContext context)
+    {
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        return context.Response.WriteAsJsonAsync(new { error = "User account is not active." });
     }
 
     private static Dictionary<Guid, ClientRole> CreateExplicitClientRoles(AppUser user)

--- a/src/MeisterProPR.Application/Interfaces/IUserAccountAuditLog.cs
+++ b/src/MeisterProPR.Application/Interfaces/IUserAccountAuditLog.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+namespace MeisterProPR.Application.Interfaces;
+
+/// <summary>
+///     Emits the structured audit trail for administrative changes to a user account's
+///     lifecycle. Event names (for example <c>user.disabled</c>, <c>user.reenabled</c>) are a
+///     contract that downstream log sinks route on, so they are produced in exactly one place.
+/// </summary>
+public interface IUserAccountAuditLog
+{
+    /// <summary>Records that an active user was disabled by an administrator.</summary>
+    void Disabled(Guid actorUserId, Guid targetUserId, string targetUsername);
+
+    /// <summary>Records that a disabled user was re-enabled by an administrator.</summary>
+    void Reenabled(Guid actorUserId, Guid targetUserId, string targetUsername);
+
+    /// <summary>
+    ///     Records that a disable request was refused because it would have left the system with no
+    ///     active global administrator. No state change occurred.
+    /// </summary>
+    void DisableBlockedByLastAdmin(Guid actorUserId, Guid targetUserId, string targetUsername);
+}

--- a/src/MeisterProPR.Application/Interfaces/IUserRepository.cs
+++ b/src/MeisterProPR.Application/Interfaces/IUserRepository.cs
@@ -27,6 +27,9 @@ public interface IUserRepository
     /// <summary>Sets the IsActive flag for the given user.</summary>
     Task SetActiveAsync(Guid id, bool isActive, CancellationToken ct = default);
 
+    /// <summary>Returns the number of users that are global administrators and currently active.</summary>
+    Task<int> CountActiveAdminsAsync(CancellationToken ct = default);
+
     /// <summary>Updates the password hash for the given user.</summary>
     Task UpdatePasswordHashAsync(Guid id, string passwordHash, CancellationToken ct = default);
 

--- a/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/IdentityAndAccessModuleServiceCollectionExtensions.cs
+++ b/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/IdentityAndAccessModuleServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ public static class IdentityAndAccessModuleServiceCollectionExtensions
 
         services.AddSingleton<IPasswordHashService, PasswordHashService>();
         services.AddSingleton<IJwtTokenService, JwtTokenService>();
+        services.AddSingleton<IUserAccountAuditLog, UserAccountAuditLog>();
 
         return services;
     }

--- a/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/UserAccountAuditLog.cs
+++ b/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/UserAccountAuditLog.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+using MeisterProPR.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace MeisterProPR.Infrastructure.Features.IdentityAndAccess;
+
+/// <summary>
+///     Serilog-backed implementation of <see cref="IUserAccountAuditLog" />. Each event carries a
+///     stable <c>AuditEvent</c> property so downstream sinks can route on it, plus the acting and
+///     target user identifiers.
+/// </summary>
+public sealed class UserAccountAuditLog(ILogger<UserAccountAuditLog> logger) : IUserAccountAuditLog
+{
+    public void Disabled(Guid actorUserId, Guid targetUserId, string targetUsername)
+    {
+        logger.LogInformation(
+            "{AuditEvent} actor={ActorUserId} target={TargetUserId} username={TargetUsername}",
+            "user.disabled",
+            actorUserId,
+            targetUserId,
+            targetUsername);
+    }
+
+    public void Reenabled(Guid actorUserId, Guid targetUserId, string targetUsername)
+    {
+        logger.LogInformation(
+            "{AuditEvent} actor={ActorUserId} target={TargetUserId} username={TargetUsername}",
+            "user.reenabled",
+            actorUserId,
+            targetUserId,
+            targetUsername);
+    }
+
+    public void DisableBlockedByLastAdmin(Guid actorUserId, Guid targetUserId, string targetUsername)
+    {
+        logger.LogWarning(
+            "{AuditEvent} blocked actor={ActorUserId} target={TargetUserId} username={TargetUsername} reason={Reason}",
+            "user.disabled",
+            actorUserId,
+            targetUserId,
+            targetUsername,
+            "last_active_admin");
+    }
+}

--- a/src/MeisterProPR.Infrastructure/Repositories/AppUserRepository.cs
+++ b/src/MeisterProPR.Infrastructure/Repositories/AppUserRepository.cs
@@ -72,6 +72,11 @@ public sealed class AppUserRepository(MeisterProPRDbContext db) : IUserRepositor
         await db.SaveChangesAsync(ct);
     }
 
+    public Task<int> CountActiveAdminsAsync(CancellationToken ct = default)
+    {
+        return db.AppUsers.CountAsync(u => u.GlobalRole == AppUserRole.Admin && u.IsActive, ct);
+    }
+
     public async Task UpdatePasswordHashAsync(Guid id, string passwordHash, CancellationToken ct = default)
     {
         var record = await db.AppUsers.FindAsync([id], ct);

--- a/tests/MeisterProPR.Api.Tests/Controllers/AdminUsersControllerTests.cs
+++ b/tests/MeisterProPR.Api.Tests/Controllers/AdminUsersControllerTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using MeisterProPR.Application.Interfaces;
+using MeisterProPR.Domain.Entities;
+using MeisterProPR.Domain.Enums;
+using MeisterProPR.Infrastructure.Auth;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+
+namespace MeisterProPR.Api.Tests.Controllers;
+
+/// <summary>Integration tests for the enable/disable flow on <c>AdminUsersController</c>.</summary>
+public sealed class AdminUsersControllerTests(AdminUsersControllerTests.AdminUsersApiFactory factory)
+    : IClassFixture<AdminUsersControllerTests.AdminUsersApiFactory>
+{
+    private static AppUser User(Guid id, bool isActive, AppUserRole role = AppUserRole.User, string username = "target")
+    {
+        return new AppUser { Id = id, Username = username, GlobalRole = role, IsActive = isActive };
+    }
+
+    private void ResetSubstitutes()
+    {
+        factory.UserRepository.ClearReceivedCalls();
+        factory.RefreshTokenRepository.ClearReceivedCalls();
+        factory.UserPatRepository.ClearReceivedCalls();
+        factory.AuditLog.ClearReceivedCalls();
+    }
+
+    private HttpRequestMessage PatchRequest(Guid id, bool isActive, string role = "Admin")
+    {
+        var request = new HttpRequestMessage(HttpMethod.Patch, $"/admin/users/{id}")
+        {
+            Content = JsonContent.Create(new { isActive }),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", factory.GenerateUserToken(Guid.NewGuid(), role));
+        return request;
+    }
+
+    [Fact]
+    public async Task Patch_DisablesActiveUser_Returns204AndRevokesAndAudits()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, true));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(3);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).SetActiveAsync(id, false, Arg.Any<CancellationToken>());
+        await factory.RefreshTokenRepository.Received(1).RevokeAllForUserAsync(id, Arg.Any<CancellationToken>());
+        await factory.UserPatRepository.Received(1).RevokeAllForUserAsync(id, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Disabled(Arg.Any<Guid>(), id, "target");
+        factory.AuditLog.DidNotReceive().Reenabled(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Patch_ReenablesDisabledUser_Returns204AndRevokesAndAudits()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, false));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, true));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).SetActiveAsync(id, true, Arg.Any<CancellationToken>());
+        await factory.RefreshTokenRepository.Received(1).RevokeAllForUserAsync(id, Arg.Any<CancellationToken>());
+        await factory.UserPatRepository.Received(1).RevokeAllForUserAsync(id, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Reenabled(Arg.Any<Guid>(), id, "target");
+    }
+
+    [Fact]
+    public async Task Patch_ReenableAlreadyActive_IsNoOp()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, true));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, true));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.DidNotReceive().SetActiveAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await factory.RefreshTokenRepository.DidNotReceive().RevokeAllForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        factory.AuditLog.DidNotReceive().Reenabled(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+        factory.AuditLog.DidNotReceive().Disabled(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Patch_DisableAlreadyDisabled_IsNoOp()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, false));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.DidNotReceive().SetActiveAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await factory.UserPatRepository.DidNotReceive().RevokeAllForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        factory.AuditLog.DidNotReceive().Disabled(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Patch_DisableLastActiveAdmin_Returns409AndAuditsBlockedAndDoesNotMutate()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, true, AppUserRole.Admin, "lastadmin"));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(1);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal("Cannot disable the last active global admin.", body.GetProperty("error").GetString());
+
+        factory.AuditLog.Received(1).DisableBlockedByLastAdmin(Arg.Any<Guid>(), id, "lastadmin");
+        factory.AuditLog.DidNotReceive().Disabled(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+        await factory.UserRepository.DidNotReceive().SetActiveAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Patch_DisableAdmin_WhenAnotherActiveAdminRemains_Succeeds()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, true, AppUserRole.Admin, "admin2"));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(2);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).SetActiveAsync(id, false, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Disabled(Arg.Any<Guid>(), id, "admin2");
+    }
+
+    [Fact]
+    public async Task Patch_ReenableAdmin_IsNeverBlockedByLastAdminGuard()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, false, AppUserRole.Admin, "admin3"));
+        // Even with zero currently-active admins, re-enabling can only add one, so it must not be blocked.
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(0);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, true));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).SetActiveAsync(id, true, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Reenabled(Arg.Any<Guid>(), id, "admin3");
+    }
+
+    [Fact]
+    public async Task Patch_UnknownUser_Returns404()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(Task.FromResult<AppUser?>(null));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Patch_NonAdminCaller_Returns403()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, true));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.PatchRequest(id, false, "User"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Patch_NoCredentials_Returns401()
+    {
+        this.ResetSubstitutes();
+        var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"/admin/users/{Guid.NewGuid()}")
+        {
+            Content = JsonContent.Create(new { isActive = false }),
+        };
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task JwtPath_DisabledUser_Returns401NotActive()
+    {
+        this.ResetSubstitutes();
+        var callerId = Guid.NewGuid();
+        factory.UserRepository.GetByIdWithAssignmentsAsync(callerId, Arg.Any<CancellationToken>())
+            .Returns(User(callerId, false, AppUserRole.Admin));
+
+        var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/admin/users");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", factory.GenerateUserToken(callerId, "Admin"));
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal("User account is not active.", body.GetProperty("error").GetString());
+
+        // Reset the caller stub so other tests keep their default (null) identity resolution.
+        factory.UserRepository.GetByIdWithAssignmentsAsync(callerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<AppUser?>(null));
+    }
+
+    public sealed class AdminUsersApiFactory : WebApplicationFactory<Program>
+    {
+        private const string TestJwtSecret = "test-jwt-secret-for-integration-tests-abc123";
+
+        public IUserRepository UserRepository { get; } = Substitute.For<IUserRepository>();
+
+        public IRefreshTokenRepository RefreshTokenRepository { get; } = Substitute.For<IRefreshTokenRepository>();
+
+        public IUserPatRepository UserPatRepository { get; } = Substitute.For<IUserPatRepository>();
+
+        public IUserAccountAuditLog AuditLog { get; } = Substitute.For<IUserAccountAuditLog>();
+
+        public string GenerateUserToken(Guid userId, string globalRole = "User")
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestJwtSecret));
+            var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(
+                    new[]
+                    {
+                        new Claim("sub", userId.ToString()),
+                        new Claim("global_role", globalRole),
+                    }),
+                Expires = DateTime.UtcNow.AddHours(1),
+                SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256),
+                Issuer = "meisterpropr",
+                Audience = "meisterpropr",
+            };
+            return handler.WriteToken(handler.CreateToken(descriptor));
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.UseSetting("DB_CONNECTION_STRING", string.Empty);
+            builder.UseSetting("MEISTER_DISABLE_HOSTED_SERVICES", "true");
+            builder.UseSetting("AI_ENDPOINT", "https://fake.openai.azure.com/");
+            builder.UseSetting("AI_DEPLOYMENT", "gpt-4o");
+            builder.UseSetting("MEISTER_CLIENT_KEYS", "test-client-key-placeholder");
+            builder.UseSetting("MEISTER_ADMIN_KEY", "admin-key-min-16-chars-ok");
+            builder.UseSetting("MEISTER_JWT_SECRET", TestJwtSecret);
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IHostedService>();
+                services.AddSingleton<IJwtTokenService, JwtTokenService>();
+
+                services.AddSingleton(Substitute.For<IPullRequestFetcher>());
+                services.AddSingleton(Substitute.For<IAdoCommentPoster>());
+                services.AddSingleton(Substitute.For<IAssignedReviewDiscoveryService>());
+                services.AddSingleton(Substitute.For<IJobRepository>());
+                services.AddSingleton(Substitute.For<IClientRegistry>());
+                services.AddSingleton(Substitute.For<IThreadMemoryRepository>());
+
+                // Caller identity resolution defaults to null so the JWT admin claim is authoritative;
+                // individual tests override this for the target user and the not-active path.
+                this.UserRepository.GetByIdWithAssignmentsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                    .Returns(Task.FromResult<AppUser?>(null));
+
+                services.AddSingleton(this.UserRepository);
+                services.AddSingleton(this.RefreshTokenRepository);
+                services.AddSingleton(this.UserPatRepository);
+                services.AddSingleton(this.AuditLog);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes #23.

## What

Replaces the one-way `DELETE /admin/users/{id}` (disable) with an idempotent **`PATCH /admin/users/{id}`** `{ "isActive": true|false }` that owns both directions.

### Backend
- **Idempotent PATCH**: `204` on success; a no-op `204` (no side effects, no audit) when the requested value already matches.
- **Token revocation** of refresh tokens + PATs whenever the flag actually flips (both directions).
- **Last-admin guard**: disabling the last active global admin returns `409 {"error":"Cannot disable the last active global admin."}`; re-enable is never blocked.
- **Audit trail** via new `IUserAccountAuditLog` — `user.disabled` / `user.reenabled` (Information) emitted only on real transitions; a blocked attempt emits a `Warning` with `Reason=last_active_admin`. Event names are the contract; centralized in one place.
- **JWT auth gap closed**: `AuthMiddleware` now rejects a disabled user on the bearer path (and, defensively, the PAT path) with `401 {"error":"User account is not active."}`, matching the refresh endpoint. No cache; one indexed lookup per request.
- `openapi.json` regenerated — `PATCH` in, delete-style operation out.

### Frontend
- `UsersView` renders **Disable** on active rows and **Re-enable** on disabled rows, both driven through the PATCH endpoint with confirm dialogs, optimistic row updates, and error toasts.
- MSW handler + generated client regenerated.

## Tests
- Backend (`AdminUsersControllerTests`, 11): disable/re-enable happy paths, idempotent no-ops both directions, last-admin guard (with blocked audit asserted), admin disable allowed when another active admin remains, re-enable of an admin never blocked, 404, 403, 401, and the JWT not-active 401.
- Frontend (`UsersView.spec`, 5): button visibility per row state, confirm accept/decline, optimistic update, error toast on non-204, Disable now uses PATCH.
- Full pre-commit gate green (entire backend suite in Release + frontend suite + lint).

## Note
This is the base of a stacked pair; the hard-delete work (#22) builds on this branch.