### PR TITLE
feat(identity): admin hard-delete of users

### DIFF
--- a/frontend/src/assets/styles/primitives.css
+++ b/frontend/src/assets/styles/primitives.css
@@ -5,7 +5,8 @@
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 .btn-primary,
 .btn-secondary,
-.btn-danger {
+.btn-danger,
+.btn-critical {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -31,7 +32,8 @@
 
 .btn-primary:disabled,
 .btn-secondary:disabled,
-.btn-danger:disabled {
+.btn-danger:disabled,
+.btn-critical:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;
@@ -55,6 +57,15 @@
 
 .btn-danger:hover {
   background: var(--color-danger-hover);
+}
+
+.btn-critical {
+  background: var(--color-critical);
+  color: #ffffff !important;
+}
+
+.btn-critical:hover {
+  background: var(--color-critical-hover);
 }
 
 .btn-ghost {

--- a/frontend/src/assets/styles/tokens.css
+++ b/frontend/src/assets/styles/tokens.css
@@ -16,6 +16,10 @@
   --color-primary-hover: #E4E4E7;
   --color-danger: #ef4444;
   --color-danger-hover: #dc2626;
+  /* Critical: irreversible actions (e.g. permanent delete). A deeper red than danger
+   * so the two destructive tiers read as distinct. */
+  --color-critical: #b91c1c;
+  --color-critical-hover: #7f1d1d;
   --color-success: #22c55e;
   --color-warning: #f59e0b;
   --color-accent: #22D3EE;

--- a/frontend/src/features/users/views/UsersView.vue
+++ b/frontend/src/features/users/views/UsersView.vue
@@ -115,6 +115,48 @@
                 >
                   {{ expandedUser === user.id ? 'Close' : 'Assignments' }}
                 </button>
+                <button
+                  class="btn-critical"
+                  :disabled="isLastActiveAdmin(user)"
+                  :title="isLastActiveAdmin(user)
+                    ? 'Cannot delete the last active administrator.'
+                    : 'Permanently delete this user'"
+                  @click="startDelete(user.id)"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+            <!-- Inline typed-confirmation for permanent delete -->
+            <tr v-if="deletingUser === user.id" class="delete-confirm-row">
+              <td colspan="5">
+                <div class="delete-confirm-panel">
+                  <p class="delete-confirm-text">
+                    This permanently deletes <strong>{{ user.username }}</strong> along with their tokens,
+                    PATs, client assignments, tenant memberships, and external identities.
+                    This cannot be undone.
+                  </p>
+                  <label :for="`delete-confirm-${user.id}`">
+                    Type <strong>{{ user.username }}</strong> to confirm:
+                  </label>
+                  <div class="delete-confirm-form">
+                    <input
+                      :id="`delete-confirm-${user.id}`"
+                      v-model="deleteConfirmText"
+                      type="text"
+                      autocomplete="off"
+                      :placeholder="user.username"
+                    />
+                    <button
+                      class="btn-critical"
+                      :disabled="deleteConfirmText !== user.username || deleteBusy === user.id"
+                      @click="confirmDelete(user)"
+                    >
+                      {{ deleteBusy === user.id ? '…' : 'Permanently delete' }}
+                    </button>
+                    <button class="btn-secondary" @click="cancelDelete">Cancel</button>
+                  </div>
+                </div>
               </td>
             </tr>
             <!-- Inline assignments panel -->
@@ -181,7 +223,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useSession } from '@/composables/useSession'
 import { useNotification } from '@/composables/useNotification'
 import { API_BASE_URL } from '@/services/apiBase'
@@ -221,6 +263,19 @@ const users = ref<UserItem[]>([])
 const loading = ref(false)
 const loadError = ref('')
 const togglingActive = ref<string | null>(null)
+
+// Hard-delete state: a typed confirmation gates the irreversible action per row.
+const deletingUser = ref<string | null>(null)
+const deleteConfirmText = ref('')
+const deleteBusy = ref<string | null>(null)
+
+const activeAdminCount = computed(
+  () => users.value.filter(u => u.isActive && u.globalRole === 'Admin').length,
+)
+
+function isLastActiveAdmin(user: UserItem): boolean {
+  return user.isActive && user.globalRole === 'Admin' && activeAdminCount.value === 1
+}
 
 // Create user state
 const showCreate = ref(false)
@@ -331,6 +386,42 @@ async function setUserActive(id: string, isActive: boolean) {
   }
 }
 
+function startDelete(id: string) {
+  deletingUser.value = id
+  deleteConfirmText.value = ''
+}
+
+function cancelDelete() {
+  deletingUser.value = null
+  deleteConfirmText.value = ''
+}
+
+async function confirmDelete(user: UserItem) {
+  // Guard against firing if the typed name no longer matches (defence in depth; the button is disabled too).
+  if (deleteConfirmText.value !== user.username) return
+  deleteBusy.value = user.id
+  try {
+    const res = await fetch(`${base}/admin/users/${user.id}/permanent`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    })
+    if (res.status === 204) {
+      users.value = users.value.filter(u => u.id !== user.id)
+      if (expandedUser.value === user.id) expandedUser.value = null
+      deletingUser.value = null
+      deleteConfirmText.value = ''
+      notify('User permanently deleted.', 'success')
+    } else {
+      const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` })) as { error?: string }
+      notify(body.error ?? `HTTP ${res.status}`, 'error')
+    }
+  } catch (e) {
+    notify(String(e), 'error')
+  } finally {
+    deleteBusy.value = null
+  }
+}
+
 async function toggleAssignments(userId: string) {
   if (expandedUser.value === userId) {
     expandedUser.value = null
@@ -429,6 +520,56 @@ select:focus { outline: none; border-color: var(--color-accent); box-shadow: 0 0
 
 .row-inactive td {
   opacity: 0.4;
+}
+
+.delete-confirm-row > td {
+  padding: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.delete-confirm-panel {
+  background: var(--color-danger-soft);
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-lg);
+  margin: 1rem 1.5rem 1.5rem 1.5rem;
+  border: 1px solid var(--color-critical);
+}
+
+.delete-confirm-text {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.delete-confirm-panel label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.delete-confirm-form {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.delete-confirm-form input {
+  flex: 0 1 18rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.delete-confirm-form input:focus {
+  outline: none;
+  border-color: var(--color-critical);
+}
+
+.delete-confirm-row:hover td {
+  background: transparent !important;
 }
 
 .actions-cell {

--- a/frontend/src/features/users/views/__tests__/UsersView.spec.ts
+++ b/frontend/src/features/users/views/__tests__/UsersView.spec.ts
@@ -30,6 +30,7 @@ function mockRes(body: unknown, status = 200) {
 
 let users: MockUser[]
 let patchResponse: () => ReturnType<typeof mockRes>
+let deleteResponse: () => ReturnType<typeof mockRes>
 
 function installFetch() {
   const fetchMock = global.fetch as unknown as Mock
@@ -37,6 +38,7 @@ function installFetch() {
     const method = opts?.method ?? 'GET'
     if (url === `${base}/admin/users` && method === 'GET') return Promise.resolve(mockRes(users))
     if (url === `${base}/clients` && method === 'GET') return Promise.resolve(mockRes([]))
+    if (url.endsWith('/permanent') && method === 'DELETE') return Promise.resolve(deleteResponse())
     if (url.startsWith(`${base}/admin/users/`) && method === 'PATCH') return Promise.resolve(patchResponse())
     return Promise.resolve(mockRes(null))
   })
@@ -49,6 +51,11 @@ function findButton(wrapper: VueWrapper, label: string) {
 function patchCalls() {
   const fetchMock = global.fetch as unknown as Mock
   return fetchMock.mock.calls.filter(c => (c[1] as RequestInit | undefined)?.method === 'PATCH')
+}
+
+function deleteCalls() {
+  const fetchMock = global.fetch as unknown as Mock
+  return fetchMock.mock.calls.filter(c => (c[1] as RequestInit | undefined)?.method === 'DELETE')
 }
 
 async function mountView() {
@@ -66,6 +73,7 @@ describe('UsersView enable/disable actions', () => {
       { id: 'disabled-user', username: 'former.employee', globalRole: 'User', isActive: false, createdAt: '2026-01-01T00:00:00Z' },
     ]
     patchResponse = () => mockRes(null, 204)
+    deleteResponse = () => mockRes(null, 204)
     window.confirm = vi.fn(() => true)
     installFetch()
   })
@@ -126,5 +134,77 @@ describe('UsersView enable/disable actions', () => {
     expect(notifyMock).toHaveBeenCalledWith('Cannot disable the last active global admin.', 'error')
     // The optimistic update must not fire on failure: the active admin keeps its Disable button.
     expect(findButton(wrapper, 'Disable')).toBeTruthy()
+  })
+})
+
+describe('UsersView permanent delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    users = [
+      { id: 'active-admin', username: 'admin', globalRole: 'Admin', isActive: true, createdAt: '2026-01-01T00:00:00Z' },
+      { id: 'disabled-user', username: 'former.employee', globalRole: 'User', isActive: false, createdAt: '2026-01-01T00:00:00Z' },
+    ]
+    patchResponse = () => mockRes(null, 204)
+    deleteResponse = () => mockRes(null, 204)
+    window.confirm = vi.fn(() => true)
+    installFetch()
+  })
+
+  function deleteButtonInRow(wrapper: VueWrapper, rowIndex: number) {
+    const row = wrapper.findAll('tbody tr')[rowIndex]
+    return row.findAll('button').find(b => b.text().trim() === 'Delete')
+  }
+
+  it('disables Delete for the last active admin and enables it for other users', async () => {
+    const wrapper = await mountView()
+
+    const adminDelete = deleteButtonInRow(wrapper, 0)
+    const userDelete = deleteButtonInRow(wrapper, 1)
+    expect(adminDelete!.attributes('disabled')).toBeDefined()
+    expect(adminDelete!.attributes('title')).toContain('last active administrator')
+    expect(userDelete!.attributes('disabled')).toBeUndefined()
+  })
+
+  it('requires typing the exact username before the permanent-delete button is enabled', async () => {
+    const wrapper = await mountView()
+
+    await deleteButtonInRow(wrapper, 1)!.trigger('click')
+    const confirmButton = findButton(wrapper, 'Permanently delete')
+    expect(confirmButton).toBeTruthy()
+    expect(confirmButton!.attributes('disabled')).toBeDefined()
+
+    await wrapper.find('.delete-confirm-form input').setValue('wrong-name')
+    expect(findButton(wrapper, 'Permanently delete')!.attributes('disabled')).toBeDefined()
+
+    await wrapper.find('.delete-confirm-form input').setValue('former.employee')
+    expect(findButton(wrapper, 'Permanently delete')!.attributes('disabled')).toBeUndefined()
+  })
+
+  it('permanently deletes the user and removes the row after the typed confirmation', async () => {
+    const wrapper = await mountView()
+
+    await deleteButtonInRow(wrapper, 1)!.trigger('click')
+    await wrapper.find('.delete-confirm-form input').setValue('former.employee')
+    await findButton(wrapper, 'Permanently delete')!.trigger('click')
+    await flushPromises()
+
+    const calls = deleteCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0][0]).toBe(`${base}/admin/users/disabled-user/permanent`)
+    expect(notifyMock).toHaveBeenCalledWith('User permanently deleted.', 'success')
+    expect(wrapper.text()).not.toContain('former.employee')
+  })
+
+  it('surfaces the server error and keeps the row on a non-204 response', async () => {
+    deleteResponse = () => mockRes({ error: 'Cannot delete the last active administrator.' }, 409)
+    const wrapper = await mountView()
+
+    await deleteButtonInRow(wrapper, 1)!.trigger('click')
+    await wrapper.find('.delete-confirm-form input').setValue('former.employee')
+    await findButton(wrapper, 'Permanently delete')!.trigger('click')
+    await flushPromises()
+
+    expect(notifyMock).toHaveBeenCalledWith('Cannot delete the last active administrator.', 'error')
+    expect(wrapper.text()).toContain('former.employee')
   })
 })

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2533,6 +2533,11 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 })
   }),
 
+  http.delete(`${base}/admin/users/:id/permanent`, async () => {
+    await delay(200)
+    return new HttpResponse(null, { status: 204 })
+  }),
+
   http.get(`${base}/users/me/pats`, async () => {
     await delay(200)
     return HttpResponse.json([

--- a/frontend/src/services/generated/openapi.ts
+++ b/frontend/src/services/generated/openapi.ts
@@ -822,6 +822,84 @@ export interface paths {
         };
         trace?: never;
     };
+    "/admin/identity/users/{id}/permanent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently deletes a user and all their dependent records. Refuses to delete the last
+         *     active global administrator.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/users/{id}/permanent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently deletes a user and all their dependent records. Refuses to delete the last
+         *     active global administrator.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/identity/users/{id}/clients": {
         parameters: {
             query?: never;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -822,6 +822,84 @@ export interface paths {
         };
         trace?: never;
     };
+    "/admin/identity/users/{id}/permanent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently deletes a user and all their dependent records. Refuses to delete the last
+         *     active global administrator.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/users/{id}/permanent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently deletes a user and all their dependent records. Refuses to delete the last
+         *     active global administrator.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/identity/users/{id}/clients": {
         parameters: {
             query?: never;

--- a/openapi.json
+++ b/openapi.json
@@ -1022,6 +1022,54 @@
         }
       }
     },
+    "/admin/identity/users/{id}/permanent": {
+      "delete": {
+        "tags": [
+          "AdminUsers"
+        ],
+        "summary": "Permanently deletes a user and all their dependent records. Refuses to delete the last\nactive global administrator.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/admin/users/{id}/permanent": {
+      "delete": {
+        "tags": [
+          "AdminUsers"
+        ],
+        "summary": "Permanently deletes a user and all their dependent records. Refuses to delete the last\nactive global administrator.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/admin/identity/users/{id}/clients": {
       "post": {
         "tags": [

--- a/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/AdminUsersController.cs
+++ b/src/MeisterProPR.Api/Features/IdentityAndAccess/Controllers/AdminUsersController.cs
@@ -139,6 +139,45 @@ public sealed class AdminUsersController(
         return this.NoContent();
     }
 
+    /// <summary>
+    ///     Permanently deletes a user and all their dependent records. Refuses to delete the last
+    ///     active global administrator.
+    /// </summary>
+    [HttpDelete("/admin/identity/users/{id:guid}/permanent")]
+    [HttpDelete("/admin/users/{id:guid}/permanent")]
+    public async Task<IActionResult> DeleteUserPermanent(Guid id, CancellationToken ct)
+    {
+        var auth = AuthHelpers.RequireAdmin(this.HttpContext);
+        if (auth is not null)
+        {
+            return auth;
+        }
+
+        var user = await userRepository.GetByIdAsync(id, ct);
+        if (user is null)
+        {
+            return this.NotFound();
+        }
+
+        var actorUserId = AuthHelpers.GetUserId(this.HttpContext) ?? Guid.Empty;
+
+        // Deleting an active admin lowers the active-admin count by one; refuse when none would remain.
+        if (user.GlobalRole == AppUserRole.Admin && user.IsActive)
+        {
+            var activeAdmins = await userRepository.CountActiveAdminsAsync(ct);
+            if (activeAdmins <= 1)
+            {
+                auditLog.DeleteBlockedByLastAdmin(actorUserId, user.Id, user.Username);
+                return this.Conflict(new { error = "Cannot delete the last active administrator." });
+            }
+        }
+
+        await userRepository.DeleteAsync(id, ct);
+        auditLog.Deleted(actorUserId, user.Id, user.Username);
+
+        return this.NoContent();
+    }
+
     /// <summary>Returns a single user with their client role assignments.</summary>
     [HttpGet("/admin/identity/users/{id:guid}")]
     [HttpGet("/admin/users/{id:guid}")]

--- a/src/MeisterProPR.Application/Interfaces/IUserAccountAuditLog.cs
+++ b/src/MeisterProPR.Application/Interfaces/IUserAccountAuditLog.cs
@@ -21,4 +21,13 @@ public interface IUserAccountAuditLog
     ///     active global administrator. No state change occurred.
     /// </summary>
     void DisableBlockedByLastAdmin(Guid actorUserId, Guid targetUserId, string targetUsername);
+
+    /// <summary>Records that a user was permanently deleted by an administrator.</summary>
+    void Deleted(Guid actorUserId, Guid targetUserId, string targetUsername);
+
+    /// <summary>
+    ///     Records that a delete request was refused because it would have left the system with no
+    ///     active global administrator. No deletion occurred.
+    /// </summary>
+    void DeleteBlockedByLastAdmin(Guid actorUserId, Guid targetUserId, string targetUsername);
 }

--- a/src/MeisterProPR.Application/Interfaces/IUserRepository.cs
+++ b/src/MeisterProPR.Application/Interfaces/IUserRepository.cs
@@ -30,6 +30,13 @@ public interface IUserRepository
     /// <summary>Returns the number of users that are global administrators and currently active.</summary>
     Task<int> CountActiveAdminsAsync(CancellationToken ct = default);
 
+    /// <summary>
+    ///     Permanently removes the user. Dependent rows (client assignments, tenant memberships,
+    ///     external identities, PATs, refresh tokens) are removed by database cascade; nullable audit
+    ///     references to the user are set to null. No-op when the user does not exist.
+    /// </summary>
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+
     /// <summary>Updates the password hash for the given user.</summary>
     Task UpdatePasswordHashAsync(Guid id, string passwordHash, CancellationToken ct = default);
 

--- a/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/UserAccountAuditLog.cs
+++ b/src/MeisterProPR.Infrastructure/Features/IdentityAndAccess/UserAccountAuditLog.cs
@@ -43,4 +43,25 @@ public sealed class UserAccountAuditLog(ILogger<UserAccountAuditLog> logger) : I
             targetUsername,
             "last_active_admin");
     }
+
+    public void Deleted(Guid actorUserId, Guid targetUserId, string targetUsername)
+    {
+        logger.LogInformation(
+            "{AuditEvent} actor={ActorUserId} target={TargetUserId} username={TargetUsername}",
+            "user.deleted",
+            actorUserId,
+            targetUserId,
+            targetUsername);
+    }
+
+    public void DeleteBlockedByLastAdmin(Guid actorUserId, Guid targetUserId, string targetUsername)
+    {
+        logger.LogWarning(
+            "{AuditEvent} blocked actor={ActorUserId} target={TargetUserId} username={TargetUsername} reason={Reason}",
+            "user.deleted",
+            actorUserId,
+            targetUserId,
+            targetUsername,
+            "last_active_admin");
+    }
 }

--- a/src/MeisterProPR.Infrastructure/Repositories/AppUserRepository.cs
+++ b/src/MeisterProPR.Infrastructure/Repositories/AppUserRepository.cs
@@ -77,6 +77,20 @@ public sealed class AppUserRepository(MeisterProPRDbContext db) : IUserRepositor
         return db.AppUsers.CountAsync(u => u.GlobalRole == AppUserRole.Admin && u.IsActive, ct);
     }
 
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var record = await db.AppUsers.FindAsync([id], ct);
+        if (record is null)
+        {
+            return;
+        }
+
+        // The dependent rows are wired with ON DELETE CASCADE and the nullable audit references with
+        // ON DELETE SET NULL, so removing the principal row is sufficient.
+        db.AppUsers.Remove(record);
+        await db.SaveChangesAsync(ct);
+    }
+
     public async Task UpdatePasswordHashAsync(Guid id, string passwordHash, CancellationToken ct = default)
     {
         var record = await db.AppUsers.FindAsync([id], ct);

--- a/tests/MeisterProPR.Api.Tests/Controllers/AdminUsersControllerTests.cs
+++ b/tests/MeisterProPR.Api.Tests/Controllers/AdminUsersControllerTests.cs
@@ -49,6 +49,13 @@ public sealed class AdminUsersControllerTests(AdminUsersControllerTests.AdminUse
         return request;
     }
 
+    private HttpRequestMessage DeleteRequest(Guid id, string role = "Admin")
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/admin/users/{id}/permanent");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", factory.GenerateUserToken(Guid.NewGuid(), role));
+        return request;
+    }
+
     [Fact]
     public async Task Patch_DisablesActiveUser_Returns204AndRevokesAndAudits()
     {
@@ -236,6 +243,104 @@ public sealed class AdminUsersControllerTests(AdminUsersControllerTests.AdminUse
         // Reset the caller stub so other tests keep their default (null) identity resolution.
         factory.UserRepository.GetByIdWithAssignmentsAsync(callerId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<AppUser?>(null));
+    }
+
+    [Fact]
+    public async Task Delete_NonAdminUser_Returns204AndDeletesAndAudits()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, true, AppUserRole.User, "victim"));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Deleted(Arg.Any<Guid>(), id, "victim");
+    }
+
+    [Fact]
+    public async Task Delete_DisabledAdmin_IsNotBlockedByLastAdminGuard()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        // A disabled admin does not count toward active admins, so deleting one is always allowed.
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, false, AppUserRole.Admin, "olddmin"));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(1);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_Admin_WhenAnotherActiveAdminRemains_Succeeds()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, true, AppUserRole.Admin, "admin2"));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(2);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.UserRepository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+        factory.AuditLog.Received(1).Deleted(Arg.Any<Guid>(), id, "admin2");
+    }
+
+    [Fact]
+    public async Task Delete_LastActiveAdmin_Returns409AndAuditsBlockedAndDoesNotDelete()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(User(id, true, AppUserRole.Admin, "lastadmin"));
+        factory.UserRepository.CountActiveAdminsAsync(Arg.Any<CancellationToken>()).Returns(1);
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal("Cannot delete the last active administrator.", body.GetProperty("error").GetString());
+
+        factory.AuditLog.Received(1).DeleteBlockedByLastAdmin(Arg.Any<Guid>(), id, "lastadmin");
+        factory.AuditLog.DidNotReceive().Deleted(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>());
+        await factory.UserRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_UnknownUser_Returns404()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(Task.FromResult<AppUser?>(null));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await factory.UserRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_NonAdminCaller_Returns403()
+    {
+        this.ResetSubstitutes();
+        var id = Guid.NewGuid();
+        factory.UserRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(User(id, true));
+
+        var client = factory.CreateClient();
+        var response = await client.SendAsync(this.DeleteRequest(id, "User"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     public sealed class AdminUsersApiFactory : WebApplicationFactory<Program>

--- a/tests/MeisterProPR.Infrastructure.Tests/Repositories/AppUserRepositoryTests.cs
+++ b/tests/MeisterProPR.Infrastructure.Tests/Repositories/AppUserRepositoryTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Andreas Rain.
+// Licensed under the Elastic License 2.0. See LICENSE file in the project root for full license terms.
+
+using MeisterProPR.Domain.Enums;
+using MeisterProPR.Infrastructure.Data;
+using MeisterProPR.Infrastructure.Data.Models;
+using MeisterProPR.Infrastructure.Repositories;
+using MeisterProPR.Infrastructure.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using FactAttribute = Xunit.SkippableFactAttribute;
+
+namespace MeisterProPR.Infrastructure.Tests.Repositories;
+
+/// <summary>Integration tests for <see cref="AppUserRepository" /> hard-delete and admin-count queries.</summary>
+[Collection("PostgresIntegration")]
+public sealed class AppUserRepositoryTests(PostgresContainerFixture fixture) : IAsyncLifetime
+{
+    private readonly List<Guid> _seededTenantIds = [];
+    private readonly List<Guid> _seededUserIds = [];
+    private DbContextOptions<MeisterProPRDbContext> _options = null!;
+
+    public Task InitializeAsync()
+    {
+        fixture.SkipIfUnavailable();
+        this._options = new DbContextOptionsBuilder<MeisterProPRDbContext>()
+            .UseNpgsql(fixture.ConnectionString, o => o.UseVector())
+            .Options;
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (this._options is null)
+        {
+            return;
+        }
+
+        await using var db = new MeisterProPRDbContext(this._options);
+
+        // Removing the tenants cascades their audit entries / memberships; remove any user that the
+        // test under inspection did not already delete.
+        await db.AppUsers.Where(u => this._seededUserIds.Contains(u.Id)).ExecuteDeleteAsync();
+        await db.TenantAuditEntries.Where(e => this._seededTenantIds.Contains(e.TenantId)).ExecuteDeleteAsync();
+        await db.Tenants.Where(t => this._seededTenantIds.Contains(t.Id)).ExecuteDeleteAsync();
+    }
+
+    private MeisterProPRDbContext NewContext()
+    {
+        return new MeisterProPRDbContext(this._options);
+    }
+
+    private static AppUserRecord NewUser(bool isActive, AppUserRole role)
+    {
+        return new AppUserRecord
+        {
+            Id = Guid.NewGuid(),
+            Username = $"user-{Guid.NewGuid():N}",
+            PasswordHash = "hash",
+            GlobalRole = role,
+            IsActive = isActive,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesUser_CascadesDependents_AndNullsAuditActor()
+    {
+        var tenantId = Guid.NewGuid();
+        this._seededTenantIds.Add(tenantId);
+        var user = NewUser(true, AppUserRole.User);
+        this._seededUserIds.Add(user.Id);
+        var auditId = Guid.NewGuid();
+
+        await using (var seed = this.NewContext())
+        {
+            seed.Tenants.Add(
+                new TenantRecord
+                {
+                    Id = tenantId,
+                    Slug = $"t-{Guid.NewGuid():N}",
+                    DisplayName = "Delete Test Tenant",
+                    IsActive = true,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                });
+            seed.AppUsers.Add(user);
+            seed.UserPats.Add(
+                new UserPatRecord
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = user.Id,
+                    TokenHash = "pat-hash",
+                    Label = "ci",
+                    CreatedAt = DateTimeOffset.UtcNow,
+                });
+            seed.RefreshTokens.Add(
+                new RefreshTokenRecord
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = user.Id,
+                    TokenHash = "refresh-hash",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddDays(1),
+                    CreatedAt = DateTimeOffset.UtcNow,
+                });
+            seed.Set<TenantMembershipRecord>().Add(
+                new TenantMembershipRecord
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    UserId = user.Id,
+                    Role = TenantRole.TenantUser,
+                    AssignedAt = DateTimeOffset.UtcNow,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                });
+            seed.TenantAuditEntries.Add(
+                new TenantAuditEntryRecord
+                {
+                    Id = auditId,
+                    TenantId = tenantId,
+                    ActorUserId = user.Id,
+                    EventType = "test.event",
+                    Summary = "seeded audit entry",
+                    OccurredAt = DateTimeOffset.UtcNow,
+                });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var act = this.NewContext())
+        {
+            var repo = new AppUserRepository(act);
+            await repo.DeleteAsync(user.Id);
+        }
+
+        await using var verify = this.NewContext();
+        Assert.Null(await verify.AppUsers.FindAsync(user.Id));
+        Assert.False(await verify.UserPats.AnyAsync(p => p.UserId == user.Id));
+        Assert.False(await verify.RefreshTokens.AnyAsync(t => t.UserId == user.Id));
+        Assert.False(await verify.Set<TenantMembershipRecord>().AnyAsync(m => m.UserId == user.Id));
+
+        var audit = await verify.TenantAuditEntries.FirstOrDefaultAsync(e => e.Id == auditId);
+        Assert.NotNull(audit);
+        Assert.Null(audit!.ActorUserId);
+    }
+
+    [Fact]
+    public async Task CountActiveAdminsAsync_CountsOnlyActiveAdmins()
+    {
+        await using var db = this.NewContext();
+        var repo = new AppUserRepository(db);
+        var baseline = await repo.CountActiveAdminsAsync();
+
+        var activeAdmin1 = NewUser(true, AppUserRole.Admin);
+        var activeAdmin2 = NewUser(true, AppUserRole.Admin);
+        var disabledAdmin = NewUser(false, AppUserRole.Admin);
+        var activeUser = NewUser(true, AppUserRole.User);
+        foreach (var u in new[] { activeAdmin1, activeAdmin2, disabledAdmin, activeUser })
+        {
+            this._seededUserIds.Add(u.Id);
+            db.AppUsers.Add(u);
+        }
+
+        await db.SaveChangesAsync();
+
+        var count = await repo.CountActiveAdminsAsync();
+
+        // Only the two active admins add to the count; the disabled admin and the active non-admin do not.
+        Assert.Equal(baseline + 2, count);
+    }
+}


### PR DESCRIPTION
Closes #22.

> **Stacked on #27 (#23).** Base branch is `feat/23-enable-disable-users`; review/merge that first. The diff here is hard-delete only.

## What

Adds an admin-only permanent delete alongside the disable/re-enable flow from #23.

### API
`DELETE /admin/users/{id}/permanent` (+ `/admin/identity/users/{id}/permanent` alias):
- `204` on success, `404` when no such user.
- `409 {"error":"Cannot delete the last active administrator."}` when the target is the only active global admin (reuses the same `CountActiveAdminsAsync` guard as #23; a disabled admin is never the blocker).
- Emits a `user.deleted` Serilog event (and a blocked `Warning` with `Reason=last_active_admin`) via `IUserAccountAuditLog`, for parity with `user.disabled`/`user.reenabled`. **The `tenant_audit_entries` table write stays out of scope** as the issue proposed.

### Persistence
`IUserRepository.DeleteAsync` removes the `AppUser` row. Existing `ON DELETE CASCADE` FKs drop client assignments, tenant memberships, external identities, PATs, and refresh tokens; the nullable `tenant_audit_entries.actor_user_id` is set null. No migration needed.

### Frontend
`UsersView` gains a `btn-critical` **Delete** action that opens an inline confirmation requiring the admin to **type the target username** before it fires. On `204` the row is removed and any open assignments panel closed; `409`/errors surface as a toast. The button is disabled with an explanatory tooltip when the target is the last active admin.

`openapi.json` + generated client regenerated; MSW handler added; new `--color-critical` token.

## Tests
- Backend controller (`AdminUsersControllerTests`, +6): delete non-admin, delete disabled-admin (not blocked), delete admin when another active admin remains, last-admin `409` (blocked audit asserted, no deletion), `404`, `403`.
- Backend integration (`AppUserRepositoryTests`, +2, real Postgres): `DeleteAsync` cascades PATs / refresh tokens / tenant memberships **and** nulls `tenant_audit_entries.actor_user_id` while keeping the row; `CountActiveAdminsAsync` counts only active admins.
- Frontend (`UsersView.spec`, +4): last-admin Delete disabled + tooltip, typed-confirmation gating, delete removes the row, `409` surfaces the message and keeps the row.
- Full pre-commit gate green (Api 487/3-skip, Infra 1188, App 415, … + frontend 465 + lint).